### PR TITLE
feat(mem): add audit lookup traces

### DIFF
--- a/active/mem/CLI.md
+++ b/active/mem/CLI.md
@@ -213,6 +213,7 @@ Required fields for every lookup record:
 | `operations` | Array | Ordered stages from the latest attempt. |
 | `attempts` | Array | Complete timing and status history for every occurrence. |
 | `hierarchy` | Array | Grounded path decisions observed during lookup. |
+| `source_scopes` | Array of paths | Ordered explicit source scopes included in the logical lookup. |
 
 Outcome fields:
 

--- a/active/mem/CLI.md
+++ b/active/mem/CLI.md
@@ -1,0 +1,354 @@
+# mem CLI reference
+
+This manual documents the unified `mem.py` entry point, including read-only
+project-context lookup and its optional conversation-scoped audit trace.
+
+## Contents
+
+- [Invocation](#invocation)
+- [`config show`](#config-show)
+- [`route`](#route)
+- [`context lookup`](#context-lookup)
+- [Audit configuration](#audit-configuration)
+- [Audit trace lifecycle](#audit-trace-lifecycle)
+- [Audit JSON Lines fields](#audit-json-lines-fields)
+- [Deduplication and timing](#deduplication-and-timing)
+- [Security and errors](#security-and-errors)
+- [`schema`](#schema)
+
+## Invocation
+
+Run from the directory containing `SKILL.md`:
+
+```bash
+python3 ./scripts/mem.py <command> [options]
+```
+
+Commands write structured JSON to standard output where applicable. Validation
+and runtime failures write an `error:` message to standard error and exit
+nonzero. `--pretty` changes JSON formatting only.
+
+## `config show`
+
+Print the merged, validated, normalized configuration:
+
+```bash
+python3 ./scripts/mem.py config show [options]
+```
+
+Options:
+
+| Option | Meaning |
+| --- | --- |
+| `--config PATH` | Load only `PATH`; do not merge nearest and home configs. |
+| `--cwd PATH` | Find the nearest ancestor `.mem.yaml` from this directory. Defaults to the current directory. |
+| `--home PATH` | Use this home directory when locating the home `.mem.yaml`. |
+| `--allow-missing-roots` | Normalize without requiring configured base roots to exist. |
+| `--pretty` | Indent JSON output. |
+
+Without `--config`, `mem` loads the nearest ancestor `.mem.yaml` first and
+`$HOME/.mem.yaml` second. Same-named bases from the nearer file take precedence;
+unique home bases remain available. The result contains:
+
+```json
+{
+  "config_path": "/absolute/project/.mem.yaml",
+  "config_paths": [
+    "/absolute/project/.mem.yaml",
+    "/absolute/home/.mem.yaml"
+  ],
+  "version": 1,
+  "audit": {
+    "enabled": true,
+    "trace_root": "/absolute/home/.config/mem/traces"
+  },
+  "bases": []
+}
+```
+
+`bases` contains normalized roots, path styles, schemas, and optional routing
+metadata. `audit` is always the effective normalized object: `enabled` defaults
+to `false`, and `trace_root` defaults to `$HOME/.config/mem/traces`.
+
+Audit settings are inherited as a whole mapping. If the nearest configuration
+declares `audit`, that mapping wins and its omitted fields receive defaults; its
+missing fields are not filled from the home audit mapping. If the nearest file
+omits `audit`, the home mapping is used.
+
+## `route`
+
+Select a configured base and explain the decision without searching it:
+
+```bash
+python3 ./scripts/mem.py route --query QUERY [options]
+```
+
+Options:
+
+| Option | Meaning |
+| --- | --- |
+| `--query TEXT` | Required user intent or artifact request. |
+| `--target NAME` | Explicit base name or alias. |
+| `--source PATH` | Source path considered by configured `source_globs`. |
+| `--artifact-kind KIND` | Explicit kind such as `guide`, `reference`, or `runbook`. |
+| `--config PATH` | Load only this configuration. |
+| `--cwd PATH` | Working directory used for lookup and `cwd_globs`. |
+| `--home PATH` | Home directory used for configuration discovery. |
+| `--allow-missing-roots` | Do not require configured roots to exist. |
+| `--pretty` | Indent JSON output. |
+
+The result status is `selected`, `ambiguous`, or `no_match`. An explicit base
+name or alias takes precedence over scored routing.
+
+## `context lookup`
+
+Search managed knowledge and, only on a managed miss, explicitly scoped source
+paths:
+
+```bash
+python3 ./scripts/mem.py context lookup \
+  --query QUERY \
+  [--target NAME] \
+  [--source PATH ...] \
+  [--artifact-kind KIND] \
+  [configuration options] \
+  [--pretty]
+```
+
+Options:
+
+| Option | Meaning |
+| --- | --- |
+| `--query TEXT` | Required lookup intent. The exact value is audited when tracing is enabled. |
+| `--target NAME` | Select an explicit configured base name or alias. |
+| `--source PATH` | Add a scoped fallback source path. Repeat for multiple scopes. |
+| `--artifact-kind KIND` | Supply a routing artifact kind explicitly. |
+| `--config PATH` | Load only this configuration. |
+| `--cwd PATH` | Working directory for configuration discovery and routing. |
+| `--home PATH` | Home directory for configuration discovery. |
+| `--allow-missing-roots` | Normalize without requiring base roots to exist. |
+| `--pretty` | Indent JSON output. |
+
+Lookup order is fixed:
+
+1. Load and validate configuration.
+2. Route the query or resolve `--target`.
+3. Resolve the selected base's configured schemas.
+4. Search the selected managed root and record one hierarchy decision per
+   configured schema, using shared query terms as evidence when present.
+5. If managed knowledge has no match, search only the repeatable `--source`
+   scopes.
+6. Return the observed outcome and, when enabled, commit its audit record.
+
+The command is read-only. It does not create schema nodes or modify files in
+the base or source scopes.
+
+The JSON result exposes:
+
+| Field | Meaning |
+| --- | --- |
+| `selection` | Selected tier, base names, and grounded routing reasons. |
+| `hierarchy` | Observed managed and fallback path decisions. |
+| `fallback` | Whether source fallback ran, its scoped paths, and why. |
+| `status` | Real terminal outcome, including matched, ambiguous, or unmatched states. |
+| `matched_paths` | Files that satisfied the lookup; empty when none matched. |
+| `candidates` | Ranked candidates returned by the router. |
+
+## Audit configuration
+
+Add an optional top-level mapping to `.mem.yaml`:
+
+```yaml
+audit:
+  enabled: true
+  trace_root: ~/.config/mem/traces
+```
+
+| Field | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `enabled` | Boolean | `false` | Enable mandatory tracing for audited lookup commands. |
+| `trace_root` | String path | `$HOME/.config/mem/traces` | Root for conversation trace files. `~` and environment variables are expanded and the result is normalized to an absolute path. |
+
+Unknown keys, non-boolean `enabled`, or invalid `trace_root` values fail
+configuration validation. Use `config show --pretty` to see the merged values
+that a lookup will use.
+
+## Audit trace lifecycle
+
+Audit-disabled lookups create no directories or files. Audit-enabled lookups
+require the active Codex thread ID in `CODEX_THREAD_ID`. Its value must be a
+valid UUID; no filename, process, or unrelated conversation is used as a
+fallback.
+
+The first audited lookup chooses:
+
+```text
+<trace_root>/<local YYYY>/<MM>/<DD>/<CODEX_THREAD_ID>.jsonl
+```
+
+The date is the user's local date at that first lookup. Every later lookup for
+the conversation reuses the same file, even after midnight. A conversation
+therefore owns exactly one trace file. Directories use mode `0700` and the file
+uses mode `0600`.
+
+Each nonempty line is one complete UTF-8 JSON object. Distinct logical lookups
+have separate lines; repeat occurrences are merged into the existing line.
+Same-conversation writes are serialized and the file is replaced atomically.
+
+## Audit JSON Lines fields
+
+Required fields for every lookup record:
+
+| Field | Shape | Meaning |
+| --- | --- | --- |
+| `version` | Integer | Trace schema version; currently `1`. |
+| `started_at` | Timestamp | Start of the first occurrence. |
+| `finished_at` | Timestamp | End of the latest occurrence. |
+| `duration_ms` | Integer | Sum of all attempt durations. |
+| `session_id` | UUID string | Validated active `CODEX_THREAD_ID`. |
+| `lookup_id` | `sha256:...` string | Stable logical-lookup fingerprint. |
+| `occurrence_count` | Integer | Number of merged occurrences. |
+| `query` | String | Exact lookup query. |
+| `commands` | Array | Commands that actually executed. |
+| `operations` | Array | Ordered stages from the latest attempt. |
+| `attempts` | Array | Complete timing and status history for every occurrence. |
+| `hierarchy` | Array | Grounded path decisions observed during lookup. |
+
+Outcome fields:
+
+| Field | Meaning |
+| --- | --- |
+| `selection` | Routing tier, selected base names, and evidence-backed reasons. |
+| `fallback` | `used`, searched `paths`, and the reason fallback did or did not run. |
+| `status` | Latest terminal lookup status. |
+| `matched_paths` | Latest matched managed or source paths. |
+
+### Commands
+
+Each `commands` entry contains:
+
+- `argv`: exact executed argument tokens in order.
+- `command`: a safely shell-quoted, replayable representation of `argv`.
+- `started_at`, `finished_at`, and `duration_ms`: execution timing.
+
+Only commands that actually execute are recorded. Internal calls are not
+invented as command entries.
+
+### Operations
+
+Each operation contains `name`, `started_at`, `finished_at`, and `duration_ms`.
+Entries are ordered and created only for stages that ran. Expected names include
+`load_config`, `route`, `resolve_schemas`, `search_managed`, and
+`search_source`; `search_source` is absent when source fallback did not run.
+
+### Attempts
+
+Each attempt contains its own `started_at`, `finished_at`, `duration_ms`,
+`command_timings`, `operation_timings`, and terminal `status`.
+`command_timings[].command_index` refers to the corresponding entry in the
+top-level `commands` array.
+
+### Hierarchy
+
+Each hierarchy decision contains:
+
+- `path`: observed managed or source path.
+- `schema`: associated schema when applicable.
+- `decision`: what the lookup did with the path, such as `searched`.
+- `reason`: concise, evidence-backed explanation.
+
+Hierarchy entries describe the selected managed root once per configured schema
+and any source fallback paths. They do not claim node inference or reasoning
+that was not observed.
+
+## Deduplication and timing
+
+`lookup_id` is the SHA-256 digest of canonical JSON containing exactly the
+logical identity inputs:
+
+- conversation session ID;
+- query;
+- ordered executed command argument arrays;
+- selected base names;
+- selected hierarchy paths; and
+- source scopes.
+
+Timestamps, durations, routing scores, outcomes, and explanatory prose are
+excluded. Consequently, changing a query, executed command, selected target,
+hierarchy path, or source scope creates a distinct record.
+
+Repeating the same identity updates one record: `occurrence_count` increments,
+the full timing snapshot is appended to `attempts`, `finished_at` and the latest
+observable outcome are refreshed, and the attempt duration is added to
+top-level `duration_ms`. `started_at` remains the first attempt's start and
+`operations` reflects only the latest attempt.
+
+Every lookup, command, and actual operation uses timezone-aware ISO 8601
+timestamps with millisecond precision. Durations are nonnegative elapsed
+milliseconds measured with a monotonic clock, so wall-clock changes do not
+corrupt elapsed timing.
+
+## Security and errors
+
+Tracing is constrained to the normalized `trace_root`. It records lookup
+metadata, never:
+
+- environment variables or their values;
+- file bodies;
+- credentials or secrets;
+- unrelated shell commands;
+- fabricated command invocations; or
+- private model reasoning.
+
+Audit-enabled lookup fails explicitly and does not perform an unlogged search
+when any required audit guarantee cannot be met. Fatal audit conditions include:
+
+- missing or invalid `CODEX_THREAD_ID`;
+- invalid audit configuration;
+- a destination that escapes `trace_root`;
+- unsafe path or session filename input;
+- inability to create or enforce `0700` directories and a `0600` file;
+- lock, atomic replacement, serialization, or update failure; and
+- malformed existing trace data that prevents a safe merge.
+
+Failed, ambiguous, and unmatched audited lookups that reach a recordable
+terminal state retain their real status and use empty selection or match fields
+where no selection occurred. Audit writes never modify managed knowledge or
+source scopes.
+
+## `schema`
+
+Inspect bundled schemas:
+
+```bash
+python3 ./scripts/mem.py schema list
+python3 ./scripts/mem.py schema show SCHEMA
+python3 ./scripts/mem.py schema describe SCHEMA
+python3 ./scripts/mem.py schema validate SCHEMA
+```
+
+Materialize under a configured base:
+
+```bash
+python3 ./scripts/mem.py schema materialize SCHEMA \
+  --base BASE \
+  [--root-relative PATH] \
+  [schema materialization options]
+```
+
+Managed mode derives output root, path style, and custom schema path from the
+selected base. `--root-relative` must resolve inside the selected base root.
+Manual `--out`, `--path-style`, and `--schema-path` overrides are rejected.
+
+Materialize an explicit non-memory artifact:
+
+```bash
+python3 ./scripts/mem.py schema materialize SCHEMA \
+  --out PATH \
+  --unmanaged \
+  [schema materialization options]
+```
+
+An explicit `--out` requires `--unmanaged`. See the
+[schema workflow](./references/schema-workflow.md) for schema fields,
+composition, and materialization options.

--- a/active/mem/README.md
+++ b/active/mem/README.md
@@ -130,6 +130,10 @@ The command:
 An ambiguous or unmatched route is reported as its real terminal status; it is
 not silently converted into a successful lookup.
 
+Managed and source traversal uses descriptor-relative, no-follow opens and
+searches only verified regular files. Oversized and probable binary files are
+skipped without reading their bodies.
+
 ## Audit traces
 
 Tracing is opt-in. With `audit.enabled: false`, or with no audit mapping,

--- a/active/mem/README.md
+++ b/active/mem/README.md
@@ -1,0 +1,233 @@
+# mem
+
+`mem` is the command-line interface for configured knowledge bases, read-only
+project-context lookup, and schema-backed artifact layouts. It merges project
+and user configuration, routes a request to a knowledge base, searches managed
+knowledge before source, and can optionally write a conversation-scoped audit
+trace for each lookup.
+
+## Contents
+
+- [Quick start](#quick-start)
+- [Configuration](#configuration)
+- [Project-context lookup](#project-context-lookup)
+- [Audit traces](#audit-traces)
+- [Schema commands](#schema-commands)
+- [More documentation](#more-documentation)
+
+## Quick start
+
+Run commands from this directory so `./scripts/mem.py` resolves correctly:
+
+```bash
+# Inspect the effective configuration.
+python3 ./scripts/mem.py config show --pretty
+
+# Search managed context, with scoped source fallback on a managed miss.
+MEM_SOURCE_ROOT=/path/to/source/repository
+python3 ./scripts/mem.py context lookup \
+  --query "gateway authentication" \
+  --target claw \
+  --source "$MEM_SOURCE_ROOT/codex/claw-gateway" \
+  --pretty
+
+# Explain routing without performing a lookup.
+python3 ./scripts/mem.py route \
+  --query "gateway authentication" \
+  --target claw \
+  --pretty
+
+# Inspect a bundled schema.
+python3 ./scripts/mem.py schema describe global-core
+```
+
+`context lookup` is read-only. It does not materialize schema nodes or modify
+managed knowledge or source files.
+
+## Configuration
+
+`mem` looks for the nearest `.mem.yaml` at or above the working directory and
+for `$HOME/.mem.yaml`. A minimal configuration with audit tracing is:
+
+```yaml
+version: 1
+bases:
+  - name: claw
+    description: Claw gateway project knowledge
+    root: ./0/notes/claw
+    schemas:
+      - name: project
+      - name: global-core
+    aliases: [claw-gateway]
+    priority: 10
+    match:
+      topics: [claw, gateway]
+      artifact_kinds: [guide, reference, spec]
+      source_globs: ["*/codex/claw-gateway/**"]
+      cwd_globs: ["*/code/openai/**"]
+
+audit:
+  enabled: true
+  trace_root: ~/.config/mem/traces
+```
+
+Each base requires `name`, `description`, `root`, and one or more `schemas`.
+Optional fields are `path_style`, `skill`, `aliases`, `priority`, and `match`.
+
+### Merge and defaults
+
+- When both files exist, the nearest configuration's base wins when the same
+  base name appears in both. Bases unique to the home configuration remain
+  available.
+- Relative base roots resolve from the configuration file that declares them.
+  Roots, custom schema paths, and the audit trace root are expanded and exposed
+  as normalized absolute paths.
+- An omitted `path_style` is inferred from the base root and otherwise defaults
+  to `directory`.
+- `audit.enabled` defaults to `false`.
+- `audit.trace_root` defaults to `$HOME/.config/mem/traces`.
+- Audit settings merge as one mapping, not field by field. When the nearest
+  configuration declares `audit`, it owns the complete effective audit mapping
+  and omitted fields receive defaults. If it does not declare `audit`, the home
+  configuration's mapping is inherited.
+- `--config PATH` loads only that file instead of merging nearest and home
+  configurations.
+
+Inspect the effective values rather than hand-parsing YAML:
+
+```bash
+python3 ./scripts/mem.py config show --pretty
+```
+
+The normalized JSON includes `config_path`, `config_paths`, `version`, `bases`,
+and the effective `audit` object. Invalid fields and types fail validation.
+
+## Project-context lookup
+
+Use `context lookup` when source work should first consult managed knowledge:
+
+```bash
+MEM_SOURCE_ROOT=/path/to/source/repository
+python3 ./scripts/mem.py context lookup \
+  --query "how tenant credentials are resolved" \
+  --target claw \
+  --source "$MEM_SOURCE_ROOT/codex/claw-gateway" \
+  --source "$MEM_SOURCE_ROOT/codex/claw-server" \
+  --pretty
+```
+
+The command:
+
+1. Loads and validates the merged configuration.
+2. Selects an explicit target or routes the query.
+3. Resolves the selected base's schemas and searches the selected managed root,
+   recording configured-schema evidence without ranking or inferring nodes.
+4. Searches each repeatable `--source` scope only when managed knowledge has no
+   match.
+5. Returns structured JSON with `selection`, `hierarchy`, `fallback`, `status`,
+   and `matched_paths`.
+
+An ambiguous or unmatched route is reported as its real terminal status; it is
+not silently converted into a successful lookup.
+
+## Audit traces
+
+Tracing is opt-in. With `audit.enabled: false`, or with no audit mapping,
+lookups behave as before and create no trace directory or file.
+
+When tracing is enabled, the active Codex conversation UUID must be present in
+`CODEX_THREAD_ID`. `mem` validates this value as a UUID and uses it directly as
+the session ID. It does not infer an ID from filenames or accept an unrelated
+conversation identifier.
+
+The first audited lookup in a conversation selects one file using the user's
+local date:
+
+```text
+<trace_root>/<YYYY>/<MM>/<DD>/<CODEX_THREAD_ID>.jsonl
+```
+
+Later lookups in the same conversation reuse that file, even after local
+midnight. Trace directories are mode `0700`; trace files are mode `0600`.
+
+Each nonempty line is an independent UTF-8 JSON object for one distinct logical
+lookup. A SHA-256 `lookup_id` fingerprints canonical JSON containing the
+session ID, query, ordered executed command arguments, selected base names,
+selected hierarchy paths, and source scopes. Timing, scores, outcomes, and
+explanatory prose do not affect the fingerprint.
+
+Repeating the same logical lookup updates its existing record instead of
+appending another line. The update increments `occurrence_count`, appends a
+complete timing snapshot to `attempts`, refreshes the latest outcome and
+`finished_at`, and adds the new attempt to `duration_ms`. Updates are serialized
+and atomically replace the trace file so concurrent lookups do not lose attempts
+or produce duplicate or partial records.
+
+Audit records include:
+
+- Identity and aggregate timing: `version`, `session_id`, `lookup_id`,
+  `started_at`, `finished_at`, `duration_ms`, and `occurrence_count`.
+- Request and execution: `query`, exact `commands[].argv`, safely quoted
+  `commands[].command`, and command timestamps.
+- Actual stages: ordered `operations` such as `load_config`, `route`,
+  `resolve_schemas`, `search_managed`, and `search_source` when fallback ran.
+- Per-occurrence history: `attempts` with command timings, operation timings,
+  duration, and terminal status.
+- Decisions and outcome: `selection`, `hierarchy`, `fallback`, `status`, and
+  `matched_paths`.
+
+Elapsed durations are nonnegative milliseconds measured with a monotonic clock;
+timestamps are timezone-aware ISO 8601 values with millisecond precision.
+Top-level `started_at` belongs to the first attempt, `finished_at` and
+`operations` describe the latest attempt, and `duration_ms` is the sum of all
+attempt durations.
+
+Tracing records command arguments and path decisions, but never environment
+variables, file bodies, credentials, unrelated shell commands, fabricated CLI
+invocations, or private model reasoning. Trace writes are contained within the
+configured trace root and never alter managed knowledge or source scopes.
+
+An audit-enabled lookup stops with an explicit audit error when the session ID
+is missing or invalid, the trace destination is unsafe, configuration is
+invalid, permissions cannot be enforced, or the trace cannot be created or
+updated. It never continues as an unlogged search.
+
+## Schema commands
+
+List, inspect, describe, or validate bundled schemas:
+
+```bash
+python3 ./scripts/mem.py schema list
+python3 ./scripts/mem.py schema show global-core
+python3 ./scripts/mem.py schema describe global-core
+python3 ./scripts/mem.py schema validate global-core
+```
+
+Materialize inside a configured base:
+
+```bash
+python3 ./scripts/mem.py schema materialize global-core \
+  --base claw \
+  --root-relative . \
+  --var cook=change-claw-config \
+  --include cook/change-claw-config \
+  --skip-existing
+```
+
+Explicit non-memory output requires `--unmanaged`:
+
+```bash
+python3 ./scripts/mem.py schema materialize integ-proof \
+  --out /tmp/proofs \
+  --unmanaged \
+  --var proof=example \
+  --include example/proof \
+  --skip-existing
+```
+
+## More documentation
+
+- [CLI command and audit field reference](./CLI.md)
+- [Audit trace feature specification](../../docs/specs/active/2026-08-06-mem-audit-traces.md)
+- [Knowledge workflow](./references/knowledge-workflow.md)
+- [Schema workflow](./references/schema-workflow.md)

--- a/active/mem/README.md
+++ b/active/mem/README.md
@@ -174,7 +174,7 @@ Audit records include:
 - Per-occurrence history: `attempts` with command timings, operation timings,
   duration, and terminal status.
 - Decisions and outcome: `selection`, `hierarchy`, `fallback`, `status`, and
-  `matched_paths`.
+  `matched_paths`; `source_scopes` records the ordered explicit fallback scopes.
 
 Elapsed durations are nonnegative milliseconds measured with a monotonic clock;
 timestamps are timezone-aware ISO 8601 values with millisecond precision.

--- a/active/mem/SKILL.md
+++ b/active/mem/SKILL.md
@@ -42,6 +42,13 @@ python3 ./scripts/mem.py config show --pretty
 # Explain base selection.
 python3 ./scripts/mem.py route --query "{{request intent}}" --pretty
 
+# Search managed context, then explicit source scopes on a miss.
+python3 ./scripts/mem.py context lookup \
+  --query "{{context query}}" \
+  --target "{{base}}" \
+  --source "{{scoped source path}}" \
+  --pretty
+
 # Inspect schemas.
 python3 ./scripts/mem.py schema list
 python3 ./scripts/mem.py schema show global-core
@@ -79,6 +86,16 @@ Load both when present. The nearest config wins when both define the same base n
 Each base requires `name`, `description`, `root`, and `schemas`. It may also define `path_style`, `skill`, `aliases`, `priority`, and deterministic `match` signals for topics, artifact kinds, source globs, and working-directory globs.
 
 Use `python3 ./scripts/mem.py config show --pretty` instead of hand-parsing configuration.
+
+An optional top-level `audit` mapping enables mandatory conversation-scoped
+lookup traces. `enabled` defaults to `false`; `trace_root` defaults to
+`$HOME/.config/mem/traces`. When enabled, `context lookup` requires the active
+conversation UUID in `CODEX_THREAD_ID` and fails closed if its trace cannot be
+prepared or atomically updated. See `./CLI.md` for the trace contract.
+
+For `context lookup`, each repeatable `--source` scope may influence routing in
+both caller-supplied and normalized form; source search still runs only after
+the selected managed root has no match.
 
 ## Managed Workflow
 

--- a/active/mem/scripts/audit_trace.py
+++ b/active/mem/scripts/audit_trace.py
@@ -13,6 +13,7 @@ import re
 import secrets
 import shlex
 import stat
+import time
 import uuid
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
@@ -24,6 +25,8 @@ from typing import Any
 TRACE_VERSION = 1
 DIRECTORY_MODE = 0o700
 FILE_MODE = 0o600
+LOCK_TIMEOUT_SECONDS = 10.0
+LOCK_RETRY_SECONDS = 0.05
 _DATE_PART = re.compile(r"^[0-9]{2}$")
 _YEAR_PART = re.compile(r"^[0-9]{4}$")
 _MILLISECOND_TIMESTAMP = re.compile(
@@ -55,9 +58,6 @@ def timestamp_ms(value: datetime) -> str:
     if value.tzinfo is None or value.utcoffset() is None:
         raise AuditTraceError("audit timestamp must be timezone-aware")
     return value.isoformat(timespec="milliseconds")
-
-
-format_timestamp = timestamp_ms
 
 
 def elapsed_ms(start_monotonic: float, finished_monotonic: float) -> int:
@@ -105,9 +105,6 @@ def shell_quote_argv(argv: Sequence[str]) -> str:
     if any("\x00" in token for token in tokens):
         raise AuditTraceError("audit command argv must not contain NUL bytes")
     return shlex.join(tokens)
-
-
-quote_argv = shell_quote_argv
 
 
 def _string_list(value: Sequence[str], field: str) -> list[str]:
@@ -175,9 +172,6 @@ def canonical_lookup_id(
         separators=(",", ":"),
     ).encode("utf-8")
     return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
-
-
-fingerprint_lookup = canonical_lookup_id
 
 
 def _validate_timestamp(value: Any, field: str) -> datetime:
@@ -440,29 +434,46 @@ class AuditTraceWriter:
         flags = os.O_RDWR | os.O_CREAT
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
+        fd: int | None = None
         try:
             fd = os.open(lock_path, flags, FILE_MODE)
             os.fchmod(fd, FILE_MODE)
             metadata = os.fstat(fd)
             if not stat.S_ISREG(metadata.st_mode):
                 raise AuditTraceError(f"audit lock is not a regular file: {lock_path}")
-            fcntl.flock(fd, fcntl.LOCK_EX)
-        except AuditTraceError:
-            if "fd" in locals():
-                os.close(fd)
-            raise
-        except OSError as exc:
-            if "fd" in locals():
-                os.close(fd)
+            deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
+            while True:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError as exc:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise AuditTraceError(
+                            f"timed out acquiring audit lock {lock_path}"
+                        ) from exc
+                    time.sleep(min(LOCK_RETRY_SECONDS, remaining))
+        except (AuditTraceError, OSError) as exc:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            if isinstance(exc, AuditTraceError):
+                raise
             raise AuditTraceError(f"could not acquire audit lock {lock_path}: {exc}") from exc
+        if fd is None:  # pragma: no cover - guarded by successful os.open above
+            raise AuditTraceError(f"could not acquire audit lock {lock_path}")
         self._lock_fd = fd
 
     def _assert_safe_trace_file(self, path: Path) -> None:
         resolved = path.resolve(strict=False)
         if not _is_relative_to(resolved, self.trace_root):
             raise AuditTraceError(f"audit trace file resolves outside trace root: {path}")
-        current = path.parent
+        current = resolved.parent
         while current != self.trace_root:
+            if current == current.parent:
+                raise AuditTraceError(f"audit trace file is not inside trace root: {path}")
             try:
                 metadata = current.lstat()
             except OSError as exc:
@@ -513,13 +524,15 @@ class AuditTraceWriter:
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
+        fd: int | None = None
         try:
             fd = os.open(path, flags, FILE_MODE)
             os.fchmod(fd, FILE_MODE)
             os.fsync(fd)
             os.close(fd)
+            fd = None
         except OSError as exc:
-            if "fd" in locals():
+            if fd is not None:
                 try:
                     os.close(fd)
                 except OSError:

--- a/active/mem/scripts/audit_trace.py
+++ b/active/mem/scripts/audit_trace.py
@@ -1,0 +1,741 @@
+#!/usr/bin/env python3
+"""Secure, conversation-scoped audit trace persistence for mem lookups."""
+
+from __future__ import annotations
+
+import copy
+import fcntl
+import hashlib
+import json
+import math
+import os
+import re
+import secrets
+import shlex
+import stat
+import uuid
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+TRACE_VERSION = 1
+DIRECTORY_MODE = 0o700
+FILE_MODE = 0o600
+_DATE_PART = re.compile(r"^[0-9]{2}$")
+_YEAR_PART = re.compile(r"^[0-9]{4}$")
+_MILLISECOND_TIMESTAMP = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+class AuditTraceError(RuntimeError):
+    """An explicit failure to safely prepare or update an audit trace."""
+
+
+def validate_session_id(session_id: str) -> str:
+    """Validate an explicitly supplied conversation UUID and return canonical text."""
+
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise AuditTraceError("audit session ID is missing; expected a conversation UUID")
+    try:
+        parsed = uuid.UUID(session_id.strip())
+    except (ValueError, AttributeError) as exc:
+        raise AuditTraceError("audit session ID must be a valid UUID") from exc
+    return str(parsed)
+
+
+def timestamp_ms(value: datetime) -> str:
+    """Return a timezone-aware ISO 8601 timestamp at millisecond precision."""
+
+    if not isinstance(value, datetime):
+        raise AuditTraceError("audit timestamp must be a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise AuditTraceError("audit timestamp must be timezone-aware")
+    return value.isoformat(timespec="milliseconds")
+
+
+format_timestamp = timestamp_ms
+
+
+def elapsed_ms(start_monotonic: float, finished_monotonic: float) -> int:
+    """Convert a monotonic-clock interval to nonnegative whole milliseconds."""
+
+    if isinstance(start_monotonic, bool) or isinstance(finished_monotonic, bool):
+        raise AuditTraceError("audit monotonic timestamps must be numbers")
+    try:
+        elapsed = float(finished_monotonic) - float(start_monotonic)
+    except (TypeError, ValueError) as exc:
+        raise AuditTraceError("audit monotonic timestamps must be numbers") from exc
+    if not math.isfinite(elapsed):
+        raise AuditTraceError("audit monotonic timestamps must be finite")
+    if elapsed < 0:
+        raise AuditTraceError("audit monotonic finish precedes start")
+    return int(round(elapsed * 1000))
+
+
+def timing_snapshot(
+    *,
+    started_at: datetime,
+    finished_at: datetime,
+    start_monotonic: float,
+    finished_monotonic: float,
+) -> dict[str, str | int]:
+    """Build the common timestamp/duration fields for a measured operation."""
+
+    return {
+        "started_at": timestamp_ms(started_at),
+        "finished_at": timestamp_ms(finished_at),
+        "duration_ms": elapsed_ms(start_monotonic, finished_monotonic),
+    }
+
+
+def shell_quote_argv(argv: Sequence[str]) -> str:
+    """Render exact argv tokens as a safely quoted, replayable shell command."""
+
+    if isinstance(argv, (str, bytes)) or not isinstance(argv, Sequence):
+        raise AuditTraceError("audit command argv must be a sequence of strings")
+    tokens = list(argv)
+    if not tokens:
+        raise AuditTraceError("audit command argv must not be empty")
+    if any(not isinstance(token, str) for token in tokens):
+        raise AuditTraceError("audit command argv must contain only strings")
+    if any("\x00" in token for token in tokens):
+        raise AuditTraceError("audit command argv must not contain NUL bytes")
+    return shlex.join(tokens)
+
+
+quote_argv = shell_quote_argv
+
+
+def _string_list(value: Sequence[str], field: str) -> list[str]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise AuditTraceError(f"{field} must be a sequence of strings")
+    result = list(value)
+    if any(not isinstance(item, str) for item in result):
+        raise AuditTraceError(f"{field} must contain only strings")
+    return result
+
+
+def canonical_lookup_payload(
+    *,
+    session_id: str,
+    query: str,
+    commands: Sequence[Sequence[str]],
+    selected_bases: Sequence[str] = (),
+    hierarchy_paths: Sequence[str] = (),
+    source_scopes: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Return the stable logical-lookup fields used by the SHA-256 fingerprint."""
+
+    canonical_session_id = validate_session_id(session_id)
+    if not isinstance(query, str):
+        raise AuditTraceError("audit query must be a string")
+    if isinstance(commands, (str, bytes)) or not isinstance(commands, Sequence):
+        raise AuditTraceError("audit commands must be an ordered sequence of argv lists")
+    normalized_commands = [
+        _string_list(argv, f"audit commands[{index}]")
+        for index, argv in enumerate(commands)
+    ]
+    return {
+        "session_id": canonical_session_id,
+        "query": query,
+        "commands": normalized_commands,
+        "selected_bases": _string_list(selected_bases, "audit selected bases"),
+        "hierarchy_paths": _string_list(hierarchy_paths, "audit hierarchy paths"),
+        "source_scopes": _string_list(source_scopes, "audit source scopes"),
+    }
+
+
+def canonical_lookup_id(
+    *,
+    session_id: str,
+    query: str,
+    commands: Sequence[Sequence[str]],
+    selected_bases: Sequence[str] = (),
+    hierarchy_paths: Sequence[str] = (),
+    source_scopes: Sequence[str] = (),
+) -> str:
+    """Fingerprint one logical lookup using canonical UTF-8 JSON."""
+
+    payload = canonical_lookup_payload(
+        session_id=session_id,
+        query=query,
+        commands=commands,
+        selected_bases=selected_bases,
+        hierarchy_paths=hierarchy_paths,
+        source_scopes=source_scopes,
+    )
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+fingerprint_lookup = canonical_lookup_id
+
+
+def _validate_timestamp(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not _MILLISECOND_TIMESTAMP.fullmatch(value):
+        raise AuditTraceError(
+            f"{field} must be a timezone-aware ISO 8601 timestamp with milliseconds"
+        )
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise AuditTraceError(f"{field} is not a valid timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise AuditTraceError(f"{field} must be timezone-aware")
+    return parsed
+
+
+def _validate_duration(value: Any, field: str) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise AuditTraceError(f"{field} must be a nonnegative integer")
+
+
+def _validate_timing(value: Any, field: str) -> None:
+    if not isinstance(value, Mapping):
+        raise AuditTraceError(f"{field} must be a mapping")
+    _validate_timestamp(value.get("started_at"), f"{field}.started_at")
+    _validate_timestamp(value.get("finished_at"), f"{field}.finished_at")
+    _validate_duration(value.get("duration_ms"), f"{field}.duration_ms")
+
+
+def _normalize_record(record: Mapping[str, Any], session_id: str) -> dict[str, Any]:
+    if not isinstance(record, Mapping):
+        raise AuditTraceError("audit trace record must be a mapping")
+    normalized = copy.deepcopy(dict(record))
+
+    supplied_version = normalized.get("version")
+    if supplied_version is not None and supplied_version != TRACE_VERSION:
+        raise AuditTraceError(f"audit record.version must be {TRACE_VERSION}")
+
+    _validate_timing(normalized, "audit record")
+
+    query = normalized.get("query")
+    if not isinstance(query, str):
+        raise AuditTraceError("audit record.query must be a string")
+
+    commands = normalized.get("commands")
+    if not isinstance(commands, list) or not commands:
+        raise AuditTraceError("audit record.commands must be a nonempty list")
+    command_argvs: list[list[str]] = []
+    for index, command in enumerate(commands):
+        field = f"audit record.commands[{index}]"
+        if not isinstance(command, Mapping):
+            raise AuditTraceError(f"{field} must be a mapping")
+        command_copy = copy.deepcopy(dict(command))
+        argv = _string_list(command_copy.get("argv"), f"{field}.argv")
+        if not argv:
+            raise AuditTraceError(f"{field}.argv must not be empty")
+        command_copy["command"] = shell_quote_argv(argv)
+        _validate_timing(command_copy, field)
+        commands[index] = command_copy
+        command_argvs.append(argv)
+
+    operations = normalized.get("operations")
+    if not isinstance(operations, list):
+        raise AuditTraceError("audit record.operations must be a list")
+    for index, operation in enumerate(operations):
+        field = f"audit record.operations[{index}]"
+        if not isinstance(operation, Mapping) or not isinstance(operation.get("name"), str):
+            raise AuditTraceError(f"{field} must have a string name")
+        _validate_timing(operation, field)
+
+    attempts = normalized.get("attempts")
+    if not isinstance(attempts, list) or not attempts:
+        raise AuditTraceError("audit record.attempts must be a nonempty list")
+    for attempt_index, attempt in enumerate(attempts):
+        field = f"audit record.attempts[{attempt_index}]"
+        if not isinstance(attempt, Mapping):
+            raise AuditTraceError(f"{field} must be a mapping")
+        _validate_timing(attempt, field)
+        if not isinstance(attempt.get("status"), str):
+            raise AuditTraceError(f"{field}.status must be a string")
+        command_timings = attempt.get("command_timings")
+        if not isinstance(command_timings, list):
+            raise AuditTraceError(f"{field}.command_timings must be a list")
+        for timing_index, command_timing in enumerate(command_timings):
+            timing_field = f"{field}.command_timings[{timing_index}]"
+            if not isinstance(command_timing, Mapping):
+                raise AuditTraceError(f"{timing_field} must be a mapping")
+            command_index = command_timing.get("command_index")
+            if (
+                not isinstance(command_index, int)
+                or isinstance(command_index, bool)
+                or command_index < 0
+                or command_index >= len(commands)
+            ):
+                raise AuditTraceError(f"{timing_field}.command_index is out of range")
+            _validate_timing(command_timing, timing_field)
+        command_indexes = [timing["command_index"] for timing in command_timings]
+        if command_indexes != list(range(len(commands))):
+            raise AuditTraceError(
+                f"{field}.command_timings must cover each command once in order"
+            )
+        operation_timings = attempt.get("operation_timings")
+        if not isinstance(operation_timings, list):
+            raise AuditTraceError(f"{field}.operation_timings must be a list")
+        for timing_index, operation_timing in enumerate(operation_timings):
+            timing_field = f"{field}.operation_timings[{timing_index}]"
+            if (
+                not isinstance(operation_timing, Mapping)
+                or not isinstance(operation_timing.get("name"), str)
+            ):
+                raise AuditTraceError(f"{timing_field} must have a string name")
+            _validate_timing(operation_timing, timing_field)
+
+    if normalized["started_at"] != attempts[0]["started_at"]:
+        raise AuditTraceError("audit record.started_at must equal the first attempt start")
+    if normalized["finished_at"] != attempts[-1]["finished_at"]:
+        raise AuditTraceError("audit record.finished_at must equal the latest attempt finish")
+    attempt_duration = sum(attempt["duration_ms"] for attempt in attempts)
+    if normalized["duration_ms"] != attempt_duration:
+        raise AuditTraceError("audit record.duration_ms must equal the sum of attempt durations")
+    if operations != attempts[-1]["operation_timings"]:
+        raise AuditTraceError("audit record.operations must reflect the latest attempt")
+
+    status = normalized.get("status")
+    if not isinstance(status, str):
+        raise AuditTraceError("audit record.status must be a string")
+    if status != attempts[-1]["status"]:
+        raise AuditTraceError("audit record.status must equal the latest attempt status")
+    matched_paths = normalized.get("matched_paths")
+    _string_list(matched_paths, "audit record.matched_paths")
+
+    fallback = normalized.get("fallback")
+    if not isinstance(fallback, Mapping):
+        raise AuditTraceError("audit record.fallback must be a mapping")
+    if not isinstance(fallback.get("used"), bool):
+        raise AuditTraceError("audit record.fallback.used must be a boolean")
+    _string_list(fallback.get("paths"), "audit record.fallback.paths")
+    if not isinstance(fallback.get("reason"), str):
+        raise AuditTraceError("audit record.fallback.reason must be a string")
+
+    hierarchy = normalized.get("hierarchy")
+    if not isinstance(hierarchy, list):
+        raise AuditTraceError("audit record.hierarchy must be a list")
+    hierarchy_paths: list[str] = []
+    for index, entry in enumerate(hierarchy):
+        field = f"audit record.hierarchy[{index}]"
+        if not isinstance(entry, Mapping):
+            raise AuditTraceError(f"{field} must be a mapping")
+        for key in ("path", "schema", "decision", "reason"):
+            if not isinstance(entry.get(key), str):
+                raise AuditTraceError(f"{field}.{key} must be a string")
+        hierarchy_paths.append(entry["path"])
+
+    selection = normalized.get("selection", {})
+    if not isinstance(selection, Mapping):
+        raise AuditTraceError("audit record.selection must be a mapping")
+    if not isinstance(selection.get("tier"), str):
+        raise AuditTraceError("audit record.selection.tier must be a string")
+    selected_bases = _string_list(selection.get("bases", []), "audit record.selection.bases")
+    _string_list(selection.get("reasons"), "audit record.selection.reasons")
+    if "source_scopes" not in normalized:
+        raise AuditTraceError(
+            "audit record.source_scopes is required for canonical fingerprinting"
+        )
+    source_scopes = _string_list(
+        normalized["source_scopes"], "audit record.source_scopes"
+    )
+
+    expected_id = canonical_lookup_id(
+        session_id=session_id,
+        query=query,
+        commands=command_argvs,
+        selected_bases=selected_bases,
+        hierarchy_paths=hierarchy_paths,
+        source_scopes=source_scopes,
+    )
+    supplied_session = normalized.get("session_id")
+    if supplied_session is not None and validate_session_id(supplied_session) != session_id:
+        raise AuditTraceError("audit record session ID does not match the writer session")
+    supplied_lookup = normalized.get("lookup_id")
+    if supplied_lookup is not None and supplied_lookup != expected_id:
+        raise AuditTraceError("audit record lookup ID does not match its canonical fingerprint")
+
+    occurrence_count = normalized.get("occurrence_count", 1)
+    _validate_duration(occurrence_count, "audit record.occurrence_count")
+    if occurrence_count != len(attempts):
+        raise AuditTraceError("audit record occurrence_count must equal the number of attempts")
+    normalized["version"] = TRACE_VERSION
+    normalized["session_id"] = session_id
+    normalized["lookup_id"] = expected_id
+    normalized["occurrence_count"] = occurrence_count
+    return normalized
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+class AuditTraceWriter:
+    """Prepare, lock, and atomically merge one conversation's JSONL trace."""
+
+    def __init__(self, trace_root: str | os.PathLike[str], session_id: str) -> None:
+        self.session_id = validate_session_id(session_id)
+        if not isinstance(trace_root, (str, os.PathLike)):
+            raise AuditTraceError("audit trace root must be a path")
+        root = Path(trace_root).expanduser()
+        if not root.is_absolute():
+            raise AuditTraceError("audit trace root must be an absolute path")
+        self.trace_root = root.resolve(strict=False)
+        if self.trace_root == Path(self.trace_root.anchor):
+            raise AuditTraceError("audit trace root must not be a filesystem root")
+        self._lock_fd: int | None = None
+        self._trace_path: Path | None = None
+
+    @property
+    def trace_path(self) -> Path:
+        if self._trace_path is None:
+            raise AuditTraceError("audit trace has not been prepared")
+        return self._trace_path
+
+    def _ensure_directory(self, path: Path) -> None:
+        resolved = path.resolve(strict=False)
+        if not _is_relative_to(resolved, self.trace_root) and resolved != self.trace_root:
+            raise AuditTraceError(f"audit directory resolves outside trace root: {path}")
+        try:
+            path.mkdir(mode=DIRECTORY_MODE, parents=False, exist_ok=True)
+            metadata = path.lstat()
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+                raise AuditTraceError(f"audit directory is not a real directory: {path}")
+            path.chmod(DIRECTORY_MODE)
+        except AuditTraceError:
+            raise
+        except OSError as exc:
+            raise AuditTraceError(f"could not create or secure audit directory {path}: {exc}") from exc
+
+    def _ensure_root(self) -> None:
+        try:
+            self.trace_root.mkdir(mode=DIRECTORY_MODE, parents=True, exist_ok=True)
+            metadata = self.trace_root.lstat()
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+                raise AuditTraceError(
+                    f"audit trace root is not a real directory: {self.trace_root}"
+                )
+            self.trace_root.chmod(DIRECTORY_MODE)
+        except AuditTraceError:
+            raise
+        except OSError as exc:
+            raise AuditTraceError(
+                f"could not create or secure audit trace root {self.trace_root}: {exc}"
+            ) from exc
+
+    def _acquire_lock(self) -> None:
+        lock_dir = self.trace_root / ".locks"
+        self._ensure_directory(lock_dir)
+        lock_path = lock_dir / f"{self.session_id}.lock"
+        flags = os.O_RDWR | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            fd = os.open(lock_path, flags, FILE_MODE)
+            os.fchmod(fd, FILE_MODE)
+            metadata = os.fstat(fd)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise AuditTraceError(f"audit lock is not a regular file: {lock_path}")
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except AuditTraceError:
+            if "fd" in locals():
+                os.close(fd)
+            raise
+        except OSError as exc:
+            if "fd" in locals():
+                os.close(fd)
+            raise AuditTraceError(f"could not acquire audit lock {lock_path}: {exc}") from exc
+        self._lock_fd = fd
+
+    def _assert_safe_trace_file(self, path: Path) -> None:
+        resolved = path.resolve(strict=False)
+        if not _is_relative_to(resolved, self.trace_root):
+            raise AuditTraceError(f"audit trace file resolves outside trace root: {path}")
+        current = path.parent
+        while current != self.trace_root:
+            try:
+                metadata = current.lstat()
+            except OSError as exc:
+                raise AuditTraceError(f"could not inspect audit trace directory {current}: {exc}") from exc
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+                raise AuditTraceError(f"unsafe audit trace directory: {current}")
+            try:
+                current.chmod(DIRECTORY_MODE)
+            except OSError as exc:
+                raise AuditTraceError(
+                    f"could not secure audit trace directory {current}: {exc}"
+                ) from exc
+            current = current.parent
+        if path.exists() or path.is_symlink():
+            try:
+                metadata = path.lstat()
+            except OSError as exc:
+                raise AuditTraceError(f"could not inspect audit trace file {path}: {exc}") from exc
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+                raise AuditTraceError(f"audit trace is not a regular file: {path}")
+
+    def _existing_trace_paths(self) -> list[Path]:
+        matches: list[Path] = []
+        try:
+            for year in self.trace_root.iterdir():
+                if not _YEAR_PART.fullmatch(year.name) or not year.is_dir():
+                    continue
+                for month in year.iterdir():
+                    if not _DATE_PART.fullmatch(month.name) or not month.is_dir():
+                        continue
+                    for day in month.iterdir():
+                        if not _DATE_PART.fullmatch(day.name) or not day.is_dir():
+                            continue
+                        try:
+                            datetime(int(year.name), int(month.name), int(day.name))
+                        except ValueError:
+                            continue
+                        candidate = day / f"{self.session_id}.jsonl"
+                        if candidate.exists() or candidate.is_symlink():
+                            self._assert_safe_trace_file(candidate)
+                            matches.append(candidate)
+        except OSError as exc:
+            raise AuditTraceError(f"could not scan audit trace root: {exc}") from exc
+        return sorted(matches)
+
+    def _create_trace_file(self, path: Path) -> None:
+        self._assert_safe_trace_file(path)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            fd = os.open(path, flags, FILE_MODE)
+            os.fchmod(fd, FILE_MODE)
+            os.fsync(fd)
+            os.close(fd)
+        except OSError as exc:
+            if "fd" in locals():
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            raise AuditTraceError(f"could not create audit trace file {path}: {exc}") from exc
+
+    def _select_trace_path(self, now: datetime) -> Path:
+        matches = self._existing_trace_paths()
+        if len(matches) > 1:
+            joined = ", ".join(str(path) for path in matches)
+            raise AuditTraceError(f"conversation has multiple audit trace files: {joined}")
+        if matches:
+            path = matches[0]
+            try:
+                path.chmod(FILE_MODE)
+            except OSError as exc:
+                raise AuditTraceError(f"could not secure audit trace file {path}: {exc}") from exc
+            return path
+
+        if now.tzinfo is None or now.utcoffset() is None:
+            raise AuditTraceError("audit trace date requires a timezone-aware datetime")
+        date_parts = (f"{now.year:04d}", f"{now.month:02d}", f"{now.day:02d}")
+        directory = self.trace_root
+        for part in date_parts:
+            directory /= part
+            self._ensure_directory(directory)
+        path = directory / f"{self.session_id}.jsonl"
+        self._create_trace_file(path)
+        return path
+
+    def _read_records(self, path: Path) -> list[dict[str, Any]]:
+        self._assert_safe_trace_file(path)
+        records: list[dict[str, Any]] = []
+        seen_lookup_ids: set[str] = set()
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                for line_number, line in enumerate(handle, start=1):
+                    if not line.strip():
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        raise AuditTraceError(
+                            f"invalid JSON in audit trace {path} at line {line_number}: {exc}"
+                        ) from exc
+                    if not isinstance(record, dict):
+                        raise AuditTraceError(
+                            f"audit trace {path} line {line_number} is not a JSON object"
+                        )
+                    if record.get("version") != TRACE_VERSION:
+                        raise AuditTraceError(
+                            f"audit trace {path} line {line_number} has unsupported version"
+                        )
+                    normalized = _normalize_record(record, self.session_id)
+                    if normalized != record:
+                        raise AuditTraceError(
+                            f"audit trace {path} line {line_number} is not canonical"
+                        )
+                    lookup_id = normalized["lookup_id"]
+                    if lookup_id in seen_lookup_ids:
+                        raise AuditTraceError(
+                            f"audit trace {path} contains duplicate lookup ID {lookup_id}"
+                        )
+                    seen_lookup_ids.add(lookup_id)
+                    records.append(normalized)
+        except AuditTraceError:
+            raise
+        except (OSError, UnicodeError) as exc:
+            raise AuditTraceError(f"could not read audit trace {path}: {exc}") from exc
+        return records
+
+    def _probe_update(self, path: Path) -> None:
+        probe = path.parent / f".{self.session_id}.{secrets.token_hex(8)}.probe"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd: int | None = None
+        try:
+            fd = os.open(probe, flags, FILE_MODE)
+            os.fchmod(fd, FILE_MODE)
+            os.fsync(fd)
+            os.close(fd)
+            fd = None
+            probe.unlink()
+        except OSError as exc:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            try:
+                probe.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise AuditTraceError(f"audit trace destination is not writable {path}: {exc}") from exc
+
+    def prepare(self, *, now: datetime | None = None) -> Path:
+        """Acquire the conversation lock and preflight its stable trace file."""
+
+        if self._lock_fd is not None:
+            raise AuditTraceError("audit trace writer is already locked")
+        current = now if now is not None else datetime.now().astimezone()
+        self._ensure_root()
+        self._acquire_lock()
+        try:
+            self._trace_path = self._select_trace_path(current)
+            self._read_records(self._trace_path)
+            self._probe_update(self._trace_path)
+            return self._trace_path
+        except Exception:
+            self.close()
+            raise
+
+    def close(self) -> None:
+        """Release a prepared writer's conversation lock."""
+
+        if self._lock_fd is None:
+            return
+        fd = self._lock_fd
+        self._lock_fd = None
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+    @contextmanager
+    def locked(self, *, now: datetime | None = None) -> Iterator[AuditTraceWriter]:
+        """Hold the conversation lock across lookup execution and trace writing."""
+
+        self.prepare(now=now)
+        try:
+            yield self
+        finally:
+            self.close()
+
+    def _merge_record(
+        self, records: list[dict[str, Any]], incoming: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        for index, existing in enumerate(records):
+            if existing.get("lookup_id") != incoming["lookup_id"]:
+                continue
+            existing_attempts = existing.get("attempts")
+            if not isinstance(existing_attempts, list):
+                raise AuditTraceError("existing audit record attempts are invalid")
+            existing_count = existing.get("occurrence_count")
+            existing_duration = existing.get("duration_ms")
+            _validate_duration(existing_count, "existing audit record.occurrence_count")
+            _validate_duration(existing_duration, "existing audit record.duration_ms")
+
+            merged = incoming
+            merged["started_at"] = existing.get("started_at")
+            merged["duration_ms"] = existing_duration + incoming["duration_ms"]
+            merged["occurrence_count"] = existing_count + incoming["occurrence_count"]
+            merged["attempts"] = copy.deepcopy(existing_attempts) + incoming["attempts"]
+            records[index] = merged
+            return records
+        records.append(incoming)
+        return records
+
+    def _atomic_replace(self, path: Path, records: list[dict[str, Any]]) -> None:
+        self._assert_safe_trace_file(path)
+        temp_path = path.parent / f".{self.session_id}.{secrets.token_hex(8)}.tmp"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd: int | None = None
+        try:
+            fd = os.open(temp_path, flags, FILE_MODE)
+            os.fchmod(fd, FILE_MODE)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                fd = None
+                for record in records:
+                    json.dump(record, handle, ensure_ascii=False, separators=(",", ":"))
+                    handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, path)
+            path.chmod(FILE_MODE)
+            directory_flags = os.O_RDONLY
+            if hasattr(os, "O_DIRECTORY"):
+                directory_flags |= os.O_DIRECTORY
+            directory_fd = os.open(path.parent, directory_flags)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except (OSError, TypeError, ValueError) as exc:
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise AuditTraceError(f"could not atomically update audit trace {path}: {exc}") from exc
+
+    def write(self, record: Mapping[str, Any]) -> Path:
+        """Merge one completed lookup record and return its stable trace path."""
+
+        if self._lock_fd is None:
+            with self.locked():
+                return self.write(record)
+        incoming = _normalize_record(record, self.session_id)
+        path = self.trace_path
+        records = self._read_records(path)
+        self._atomic_replace(path, self._merge_record(records, incoming))
+        return path
+
+
+def write_audit_trace(
+    trace_root: str | os.PathLike[str],
+    session_id: str,
+    record: Mapping[str, Any],
+) -> Path:
+    """One-shot convenience wrapper for callers that do not need preflight locking."""
+
+    return AuditTraceWriter(trace_root, session_id).write(record)

--- a/active/mem/scripts/context.py
+++ b/active/mem/scripts/context.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""Read-only managed context lookup with optional conversation audit tracing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from contextlib import nullcontext
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+from audit_trace import (
+    AuditTraceError,
+    AuditTraceWriter,
+    elapsed_ms,
+    shell_quote_argv,
+    timestamp_ms,
+)
+from load_config import load_config
+from route import route
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_DIR = SCRIPT_DIR.parent
+BUNDLED_SCHEMAS = SKILL_DIR / "references" / "schemas"
+SESSION_ENV = "CODEX_THREAD_ID"
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+@dataclass
+class OperationSpan:
+    name: str
+    started_at: datetime
+    started_monotonic: float
+
+
+class OperationRecorder:
+    def __init__(self) -> None:
+        self.operations: list[dict[str, Any]] = []
+
+    def start(self, name: str) -> OperationSpan:
+        return OperationSpan(name, datetime.now().astimezone(), time.monotonic())
+
+    def finish(self, span: OperationSpan) -> None:
+        finished_at = datetime.now().astimezone()
+        self.operations.append(
+            {
+                "name": span.name,
+                "started_at": timestamp_ms(span.started_at),
+                "finished_at": timestamp_ms(finished_at),
+                "duration_ms": elapsed_ms(span.started_monotonic, time.monotonic()),
+            }
+        )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="context_command", required=True)
+    lookup = subparsers.add_parser("lookup", help="Search managed knowledge, then source scopes.")
+    lookup.add_argument("--query", required=True, help="Context to find.")
+    lookup.add_argument("--target", help="Explicit base name or alias.")
+    lookup.add_argument(
+        "--source",
+        action="append",
+        default=[],
+        help="Scoped source path to search on fallback; may be repeated.",
+    )
+    lookup.add_argument("--artifact-kind", help="Optional routing artifact kind.")
+    lookup.add_argument("--config", type=Path, help="Use only this .mem.yaml.")
+    lookup.add_argument("--cwd", type=Path, default=Path.cwd())
+    lookup.add_argument("--home", type=Path, default=Path.home())
+    lookup.add_argument("--allow-missing-roots", action="store_true")
+    lookup.add_argument("--pretty", action="store_true")
+    return parser.parse_args(argv)
+
+
+def schema_path(schema: dict[str, str]) -> Path:
+    if "path" in schema:
+        return Path(schema["path"])
+    return BUNDLED_SCHEMAS / schema["name"] / "schema.yaml"
+
+
+def _schema_descriptions(value: Any) -> Iterator[str]:
+    if isinstance(value, dict):
+        description = value.get("description")
+        if isinstance(description, str) and description.strip():
+            yield description.strip()
+        for child in value.values():
+            yield from _schema_descriptions(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _schema_descriptions(child)
+
+
+def resolve_schemas(base: dict[str, Any], query: str) -> list[dict[str, Any]]:
+    query_words = set(re.findall(r"[a-z0-9]+", query.casefold()))
+    resolved: list[dict[str, Any]] = []
+    for schema in base["schemas"]:
+        path = schema_path(schema).resolve(strict=False)
+        if not path.is_file():
+            raise ValueError(f"schema {schema['name']!r} does not exist: {path}")
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, yaml.YAMLError) as exc:
+            raise ValueError(f"could not resolve schema {schema['name']!r}: {exc}") from exc
+        descriptions = list(_schema_descriptions(data))
+        shared_words = sorted(
+            query_words.intersection(
+                word
+                for description in descriptions
+                for word in re.findall(r"[a-z0-9]+", description.casefold())
+            )
+        )
+        resolved.append(
+            {
+                "name": schema["name"],
+                "path": str(path),
+                "shared_query_words": shared_words,
+            }
+        )
+    return resolved
+
+
+def _iter_search_files(scope: Path) -> Iterator[Path]:
+    if scope.is_file():
+        yield scope
+        return
+    for path in sorted(scope.rglob("*")):
+        if path.is_file() and not path.is_symlink():
+            yield path
+
+
+def search_scope(scope: Path, query: str) -> list[str]:
+    resolved_scope = scope.expanduser().resolve(strict=False)
+    if not resolved_scope.exists():
+        raise ValueError(f"search scope does not exist: {resolved_scope}")
+    normalized_query = query.casefold().strip()
+    query_words = [word for word in re.findall(r"[a-z0-9]+", normalized_query) if len(word) > 1]
+    matches: list[str] = []
+    for path in _iter_search_files(resolved_scope):
+        path_text = str(path).casefold()
+        try:
+            body = path.read_text(encoding="utf-8", errors="ignore").casefold()
+        except OSError:
+            continue
+        haystack = f"{path_text}\n{body}"
+        if normalized_query in haystack or (query_words and all(word in haystack for word in query_words)):
+            matches.append(str(path.resolve(strict=False)))
+    return matches
+
+
+def selection_from_route(result: dict[str, Any], target: str | None) -> dict[str, Any]:
+    selected = result.get("selected")
+    if not selected:
+        return {"tier": "none", "bases": [], "reasons": []}
+    return {
+        "tier": "explicit" if target else "routed",
+        "bases": [selected["name"]],
+        "reasons": list(selected.get("reasons", [])),
+    }
+
+
+def hierarchy_for_search(base: dict[str, Any], schemas: list[dict[str, Any]]) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    for schema in schemas:
+        shared_words = schema["shared_query_words"]
+        if shared_words:
+            evidence = ", ".join(shared_words)
+            reason = (
+                f"Configured schema {schema['name']!r} has node descriptions sharing "
+                f"query terms ({evidence}); searched the selected managed root."
+            )
+        else:
+            reason = (
+                f"Configured schema {schema['name']!r} belongs to the selected base; "
+                "searched the selected managed root without claiming a node inference."
+            )
+        entries.append(
+            {
+                "path": str(Path(base["root"]).resolve(strict=False)),
+                "schema": schema["name"],
+                "decision": "searched",
+                "reason": reason,
+            }
+        )
+    return entries
+
+
+def _command_argv(explicit: list[str] | None) -> list[str]:
+    if explicit is not None:
+        return list(explicit)
+    original = getattr(sys, "orig_argv", None)
+    if isinstance(original, list) and original:
+        return [str(value) for value in original]
+    return [sys.executable, *sys.argv]
+
+
+def _record(
+    *,
+    session_id: str,
+    query: str,
+    argv: list[str],
+    started_at: datetime,
+    started_monotonic: float,
+    operations: list[dict[str, Any]],
+    selection: dict[str, Any],
+    hierarchy: list[dict[str, str]],
+    fallback: dict[str, Any],
+    status: str,
+    matched_paths: list[str],
+    source_scopes: list[str],
+) -> dict[str, Any]:
+    finished_at = datetime.now().astimezone()
+    duration = elapsed_ms(started_monotonic, time.monotonic())
+    started_text = timestamp_ms(started_at)
+    finished_text = timestamp_ms(finished_at)
+    command = {
+        "argv": argv,
+        "command": shell_quote_argv(argv),
+        "started_at": started_text,
+        "finished_at": finished_text,
+        "duration_ms": duration,
+    }
+    attempt = {
+        "started_at": started_text,
+        "finished_at": finished_text,
+        "duration_ms": duration,
+        "command_timings": [
+            {
+                "command_index": 0,
+                "started_at": started_text,
+                "finished_at": finished_text,
+                "duration_ms": duration,
+            }
+        ],
+        "operation_timings": [dict(operation) for operation in operations],
+        "status": status,
+    }
+    return {
+        "version": 1,
+        "started_at": started_text,
+        "finished_at": finished_text,
+        "duration_ms": duration,
+        "session_id": session_id,
+        "occurrence_count": 1,
+        "query": query,
+        "commands": [command],
+        "operations": [dict(operation) for operation in operations],
+        "attempts": [attempt],
+        "selection": selection,
+        "hierarchy": hierarchy,
+        "fallback": fallback,
+        "status": status,
+        "matched_paths": matched_paths,
+        "source_scopes": source_scopes,
+    }
+
+
+def lookup(
+    args: argparse.Namespace,
+    *,
+    command_argv: list[str] | None = None,
+) -> tuple[dict[str, Any], str | None]:
+    started_at = datetime.now().astimezone()
+    started_monotonic = time.monotonic()
+    recorder = OperationRecorder()
+
+    load_span = recorder.start("load_config")
+    try:
+        config = load_config(
+            cwd=args.cwd,
+            home=args.home,
+            config=args.config,
+            require_roots=not args.allow_missing_roots,
+        )
+    finally:
+        recorder.finish(load_span)
+
+    audit = config["audit"]
+    audit_enabled = bool(audit["enabled"])
+    session_id = os.environ.get(SESSION_ENV, "") if audit_enabled else ""
+    source_scopes = [str(Path(source).expanduser().resolve(strict=False)) for source in args.source]
+    argv = _command_argv(command_argv)
+    writer = (
+        AuditTraceWriter(Path(audit["trace_root"]), session_id)
+        if audit_enabled
+        else None
+    )
+
+    route_result: dict[str, Any] = {"status": "no_match", "selected": None, "candidates": []}
+    selection: dict[str, Any] = {"tier": "none", "bases": [], "reasons": []}
+    hierarchy: list[dict[str, str]] = []
+    fallback: dict[str, Any] = {"used": False, "paths": [], "reason": "Lookup did not search source."}
+    status = "error"
+    matched_paths: list[str] = []
+    error: str | None = None
+
+    lock_context = writer.locked(now=started_at) if writer is not None else nullcontext()
+    try:
+        with lock_context:
+            try:
+                route_span = recorder.start("route")
+                try:
+                    route_result = route(
+                        config,
+                        query=args.query,
+                        cwd=args.cwd,
+                        source=[*args.source, *source_scopes],
+                        artifact_kind=args.artifact_kind,
+                        target=args.target,
+                    )
+                finally:
+                    recorder.finish(route_span)
+                selection = selection_from_route(route_result, args.target)
+
+                if route_result["status"] == "ambiguous":
+                    status = "ambiguous"
+                    fallback = {
+                        "used": False,
+                        "paths": [],
+                        "reason": "Routing was ambiguous, so no path was searched.",
+                    }
+                elif route_result["status"] != "selected":
+                    status = "unmatched"
+                    fallback = {
+                        "used": False,
+                        "paths": [],
+                        "reason": "No base was selected, so no path was searched.",
+                    }
+                else:
+                    selected_name = route_result["selected"]["name"]
+                    base = next(base for base in config["bases"] if base["name"] == selected_name)
+
+                    schema_span = recorder.start("resolve_schemas")
+                    try:
+                        schemas = resolve_schemas(base, args.query)
+                    finally:
+                        recorder.finish(schema_span)
+                    hierarchy = hierarchy_for_search(base, schemas)
+
+                    managed_span = recorder.start("search_managed")
+                    try:
+                        matched_paths = search_scope(Path(base["root"]), args.query)
+                    finally:
+                        recorder.finish(managed_span)
+
+                    if matched_paths:
+                        status = "matched"
+                        fallback = {
+                            "used": False,
+                            "paths": [],
+                            "reason": "Managed knowledge contained at least one matching file.",
+                        }
+                    elif source_scopes:
+                        fallback = {
+                            "used": True,
+                            "paths": source_scopes,
+                            "reason": "Managed knowledge had no match; searched explicit source scopes.",
+                        }
+                        for source in source_scopes:
+                            hierarchy.append(
+                                {
+                                    "path": source,
+                                    "schema": "source",
+                                    "decision": "searched",
+                                    "reason": "Explicit source scope searched after managed knowledge had no match.",
+                                }
+                            )
+                        source_span = recorder.start("search_source")
+                        try:
+                            source_matches: list[str] = []
+                            for source in source_scopes:
+                                source_matches.extend(search_scope(Path(source), args.query))
+                            matched_paths = sorted(dict.fromkeys(source_matches))
+                        finally:
+                            recorder.finish(source_span)
+                        status = "matched" if matched_paths else "unmatched"
+                    else:
+                        status = "unmatched"
+                        fallback = {
+                            "used": False,
+                            "paths": [],
+                            "reason": "Managed knowledge had no match and no source scopes were provided.",
+                        }
+            except (OSError, ValueError, KeyError, StopIteration) as exc:
+                status = "error"
+                error = str(exc)
+
+            result = {
+                "selection": selection,
+                "hierarchy": hierarchy,
+                "fallback": fallback,
+                "status": status,
+                "matched_paths": matched_paths,
+                "candidates": route_result.get("candidates", []),
+            }
+            if writer is not None:
+                writer.write(
+                    _record(
+                        session_id=session_id,
+                        query=args.query,
+                        argv=argv,
+                        started_at=started_at,
+                        started_monotonic=started_monotonic,
+                        operations=recorder.operations,
+                        selection=selection,
+                        hierarchy=hierarchy,
+                        fallback=fallback,
+                        status=status,
+                        matched_paths=matched_paths,
+                        source_scopes=source_scopes,
+                    )
+                )
+            return result, error
+    except AuditTraceError as exc:
+        raise AuditTraceError(f"audit trace failed: {exc}") from exc
+
+
+def main(argv: list[str] | None = None, *, command_argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    try:
+        result, error = lookup(args, command_argv=command_argv)
+    except AuditTraceError as exc:
+        fail(str(exc))
+    if error is not None:
+        fail(error)
+    json.dump(result, sys.stdout, indent=2 if args.pretty else None)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/active/mem/scripts/context.py
+++ b/active/mem/scripts/context.py
@@ -13,7 +13,7 @@ from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, NoReturn
 
 import yaml
 
@@ -32,9 +32,11 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 SKILL_DIR = SCRIPT_DIR.parent
 BUNDLED_SCHEMAS = SKILL_DIR / "references" / "schemas"
 SESSION_ENV = "CODEX_THREAD_ID"
+MAX_SEARCH_BYTES = 2 * 1024 * 1024
+BINARY_SNIFF_BYTES = 8192
 
 
-def fail(message: str) -> None:
+def fail(message: str) -> NoReturn:
     print(f"error: {message}", file=sys.stderr)
     raise SystemExit(2)
 
@@ -134,12 +136,36 @@ def resolve_schemas(base: dict[str, Any], query: str) -> list[dict[str, Any]]:
 
 
 def _iter_search_files(scope: Path) -> Iterator[Path]:
-    if scope.is_file():
+    if scope.is_file() and not scope.is_symlink():
         yield scope
         return
-    for path in sorted(scope.rglob("*")):
-        if path.is_file() and not path.is_symlink():
-            yield path
+    pending = [scope]
+    while pending:
+        directory = pending.pop()
+        try:
+            entries = sorted(directory.iterdir(), key=lambda path: path.name)
+        except OSError:
+            continue
+        child_directories: list[Path] = []
+        for path in entries:
+            try:
+                if path.is_symlink():
+                    continue
+                if path.is_file():
+                    yield path
+                elif path.is_dir():
+                    child_directories.append(path)
+            except OSError:
+                continue
+        pending.extend(reversed(child_directories))
+
+
+def _is_probable_binary(path: Path) -> bool:
+    try:
+        with path.open("rb") as handle:
+            return b"\x00" in handle.read(BINARY_SNIFF_BYTES)
+    except OSError:
+        return True
 
 
 def search_scope(scope: Path, query: str) -> list[str]:
@@ -151,14 +177,30 @@ def search_scope(scope: Path, query: str) -> list[str]:
     matches: list[str] = []
     for path in _iter_search_files(resolved_scope):
         path_text = str(path).casefold()
+        path_matches = normalized_query in path_text or (
+            query_words and all(word in path_text for word in query_words)
+        )
+        if path_matches:
+            matches.append(str(path.resolve(strict=False)))
+            continue
         try:
-            body = path.read_text(encoding="utf-8", errors="ignore").casefold()
+            if path.stat().st_size > MAX_SEARCH_BYTES or _is_probable_binary(path):
+                continue
+            found_words: set[str] = set()
+            phrase_match = False
+            with path.open("r", encoding="utf-8", errors="ignore") as handle:
+                for line in handle:
+                    normalized_line = line.casefold()
+                    if normalized_query in normalized_line:
+                        phrase_match = True
+                        break
+                    if query_words:
+                        found_words.update(word for word in query_words if word in normalized_line)
         except OSError:
             continue
-        haystack = f"{path_text}\n{body}"
-        if normalized_query in haystack or (query_words and all(word in haystack for word in query_words)):
+        if phrase_match or (query_words and all(word in found_words for word in query_words)):
             matches.append(str(path.resolve(strict=False)))
-    return matches
+    return sorted(matches)
 
 
 def selection_from_route(result: dict[str, Any], target: str | None) -> dict[str, Any]:
@@ -311,6 +353,8 @@ def lookup(
     try:
         with lock_context:
             try:
+                if not args.query.strip():
+                    raise ValueError("query must not be empty")
                 route_span = recorder.start("route")
                 try:
                     route_result = route(
@@ -366,26 +410,29 @@ def lookup(
                     elif source_scopes:
                         fallback = {
                             "used": True,
-                            "paths": source_scopes,
-                            "reason": "Managed knowledge had no match; searched explicit source scopes.",
+                            "paths": [],
+                            "reason": "Managed knowledge had no match; searching explicit source scopes.",
                         }
-                        for source in source_scopes:
-                            hierarchy.append(
-                                {
-                                    "path": source,
-                                    "schema": "source",
-                                    "decision": "searched",
-                                    "reason": "Explicit source scope searched after managed knowledge had no match.",
-                                }
-                            )
                         source_span = recorder.start("search_source")
                         try:
                             source_matches: list[str] = []
                             for source in source_scopes:
                                 source_matches.extend(search_scope(Path(source), args.query))
+                                fallback["paths"].append(source)
+                                hierarchy.append(
+                                    {
+                                        "path": source,
+                                        "schema": "source",
+                                        "decision": "searched",
+                                        "reason": "Explicit source scope searched after managed knowledge had no match.",
+                                    }
+                                )
                             matched_paths = sorted(dict.fromkeys(source_matches))
                         finally:
                             recorder.finish(source_span)
+                        fallback["reason"] = (
+                            "Managed knowledge had no match; searched explicit source scopes."
+                        )
                         status = "matched" if matched_paths else "unmatched"
                     else:
                         status = "unmatched"

--- a/active/mem/scripts/context.py
+++ b/active/mem/scripts/context.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import re
+import stat
 import sys
 import time
 from contextlib import nullcontext
@@ -135,37 +136,80 @@ def resolve_schemas(base: dict[str, Any], query: str) -> list[dict[str, Any]]:
     return resolved
 
 
-def _iter_search_files(scope: Path) -> Iterator[Path]:
-    if scope.is_file() and not scope.is_symlink():
-        yield scope
-        return
-    pending = [scope]
-    while pending:
-        directory = pending.pop()
-        try:
-            entries = sorted(directory.iterdir(), key=lambda path: path.name)
-        except OSError:
-            continue
-        child_directories: list[Path] = []
-        for path in entries:
-            try:
-                if path.is_symlink():
-                    continue
-                if path.is_file():
-                    yield path
-                elif path.is_dir():
-                    child_directories.append(path)
-            except OSError:
-                continue
-        pending.extend(reversed(child_directories))
+def _search_open_flags() -> int:
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise ValueError("secure source search requires O_NOFOLLOW support")
+    flags = os.O_RDONLY
+    for name in ("O_CLOEXEC", "O_NOFOLLOW", "O_NONBLOCK"):
+        flags |= getattr(os, name, 0)
+    return flags
 
 
-def _is_probable_binary(path: Path) -> bool:
+def _walk_search_directory(
+    directory_fd: int,
+    directory_path: Path,
+    flags: int,
+) -> Iterator[tuple[Path, int, os.stat_result]]:
     try:
-        with path.open("rb") as handle:
-            return b"\x00" in handle.read(BINARY_SNIFF_BYTES)
+        with os.scandir(directory_fd) as entries:
+            names = sorted(entry.name for entry in entries)
+    except OSError:
+        return
+    for name in names:
+        child_fd: int | None = None
+        try:
+            child_fd = os.open(name, flags, dir_fd=directory_fd)
+            metadata = os.fstat(child_fd)
+        except OSError:
+            if child_fd is not None:
+                try:
+                    os.close(child_fd)
+                except OSError:
+                    pass
+            continue
+        child_path = directory_path / name
+        try:
+            if stat.S_ISREG(metadata.st_mode):
+                yield child_path, child_fd, metadata
+            elif stat.S_ISDIR(metadata.st_mode):
+                yield from _walk_search_directory(child_fd, child_path, flags)
+        finally:
+            try:
+                os.close(child_fd)
+            except OSError:
+                pass
+
+
+def _iter_search_files(scope: Path) -> Iterator[tuple[Path, int, os.stat_result]]:
+    flags = _search_open_flags()
+    try:
+        root_fd = os.open(scope, flags)
+    except OSError as exc:
+        raise ValueError(f"could not open search scope {scope}: {exc}") from exc
+    try:
+        metadata = os.fstat(root_fd)
+        if stat.S_ISREG(metadata.st_mode):
+            yield scope, root_fd, metadata
+        elif stat.S_ISDIR(metadata.st_mode):
+            yield from _walk_search_directory(root_fd, scope, flags)
+    finally:
+        try:
+            os.close(root_fd)
+        except OSError:
+            pass
+
+
+def _is_probable_binary(fd: int) -> bool:
+    try:
+        os.lseek(fd, 0, os.SEEK_SET)
+        return b"\x00" in os.read(fd, BINARY_SNIFF_BYTES)
     except OSError:
         return True
+    finally:
+        try:
+            os.lseek(fd, 0, os.SEEK_SET)
+        except OSError:
+            pass
 
 
 def search_scope(scope: Path, query: str) -> list[str]:
@@ -175,20 +219,20 @@ def search_scope(scope: Path, query: str) -> list[str]:
     normalized_query = query.casefold().strip()
     query_words = [word for word in re.findall(r"[a-z0-9]+", normalized_query) if len(word) > 1]
     matches: list[str] = []
-    for path in _iter_search_files(resolved_scope):
+    for path, fd, metadata in _iter_search_files(resolved_scope):
         path_text = str(path).casefold()
         path_matches = normalized_query in path_text or (
             query_words and all(word in path_text for word in query_words)
         )
         if path_matches:
-            matches.append(str(path.resolve(strict=False)))
+            matches.append(str(path))
             continue
         try:
-            if path.stat().st_size > MAX_SEARCH_BYTES or _is_probable_binary(path):
+            if metadata.st_size > MAX_SEARCH_BYTES or _is_probable_binary(fd):
                 continue
             found_words: set[str] = set()
             phrase_match = False
-            with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            with os.fdopen(os.dup(fd), "r", encoding="utf-8", errors="ignore") as handle:
                 for line in handle:
                     normalized_line = line.casefold()
                     if normalized_query in normalized_line:
@@ -199,7 +243,7 @@ def search_scope(scope: Path, query: str) -> list[str]:
         except OSError:
             continue
         if phrase_match or (query_words and all(word in found_words for word in query_words)):
-            matches.append(str(path.resolve(strict=False)))
+            matches.append(str(path))
     return sorted(matches)
 
 

--- a/active/mem/scripts/load_config.py
+++ b/active/mem/scripts/load_config.py
@@ -200,7 +200,7 @@ def load_yaml(path: Path) -> Any:
         fail(f"could not read {path}: {exc}")
 
 
-def normalize_config(path: Path, require_roots: bool, home: Path) -> dict[str, Any]:
+def normalize_config(path: Path, require_roots: bool, home: Path) -> tuple[dict[str, Any], bool]:
     data = load_yaml(path)
     if not isinstance(data, dict):
         fail("config must be a YAML mapping")
@@ -269,26 +269,26 @@ def normalize_config(path: Path, require_roots: bool, home: Path) -> dict[str, A
         "version": 1,
         "bases": normalized_bases,
         "audit": default_audit(home),
-        "_audit_declared": "audit" in data,
     }
+    audit_declared = "audit" in data
     if "audit" in data:
         normalized_config["audit"] = normalize_audit(data["audit"], "audit", path.parent, home)
-    return normalized_config
+    return normalized_config, audit_declared
 
 
 def merge_configs(paths: list[Path], require_roots: bool, home: Path) -> dict[str, Any]:
     normalized_configs = [normalize_config(path, require_roots, home) for path in paths]
     merged_bases: list[dict[str, Any]] = []
     seen_names: set[str] = set()
-    for config in normalized_configs:
+    for config, _ in normalized_configs:
         for base in config["bases"]:
             if base["name"] in seen_names:
                 continue
             seen_names.add(base["name"])
             merged_bases.append(base)
     audit = default_audit(home)
-    for config in normalized_configs:
-        if config["_audit_declared"]:
+    for config, audit_declared in normalized_configs:
+        if audit_declared:
             audit = config["audit"]
             break
     return {

--- a/active/mem/scripts/load_config.py
+++ b/active/mem/scripts/load_config.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -22,6 +23,7 @@ except ImportError:  # pragma: no cover - environment issue
 PATH_STYLES = {"directory", "dotted"}
 DEFAULT_PATH_STYLE = "directory"
 MATCH_FIELDS = {"topics", "artifact_kinds", "source_globs", "cwd_globs"}
+AUDIT_FIELDS = {"enabled", "trace_root"}
 
 
 def fail(message: str) -> None:
@@ -129,6 +131,38 @@ def resolve_root(raw_root: str, config_dir: Path) -> Path:
     return path.resolve(strict=False)
 
 
+def default_audit(home: Path) -> dict[str, Any]:
+    trace_root = home.expanduser().resolve(strict=False) / ".config" / "mem" / "traces"
+    return {
+        "enabled": False,
+        "trace_root": str(trace_root),
+    }
+
+
+def normalize_audit(value: Any, field: str, config_dir: Path, home: Path) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail(f"{field} must be a mapping")
+
+    extra_keys = set(value) - AUDIT_FIELDS
+    if extra_keys:
+        joined = ", ".join(sorted(extra_keys))
+        fail(f"{field} has unsupported key(s): {joined}")
+
+    normalized = default_audit(home)
+    if "enabled" in value:
+        enabled = value["enabled"]
+        if not isinstance(enabled, bool):
+            fail(f"{field}.enabled must be a boolean")
+        normalized["enabled"] = enabled
+    if "trace_root" in value:
+        raw_trace_root = non_empty_string(value["trace_root"], f"{field}.trace_root")
+        expanded = os.path.expandvars(os.path.expanduser(raw_trace_root))
+        if re.search(r"\$(?:[A-Za-z_][A-Za-z0-9_]*|\{[^}]+\})", expanded):
+            fail(f"{field}.trace_root contains an unresolved environment variable")
+        normalized["trace_root"] = str(resolve_root(raw_trace_root, config_dir))
+    return normalized
+
+
 def infer_path_style(root: Path) -> str:
     if not root.is_dir():
         return DEFAULT_PATH_STYLE
@@ -166,7 +200,7 @@ def load_yaml(path: Path) -> Any:
         fail(f"could not read {path}: {exc}")
 
 
-def normalize_config(path: Path, require_roots: bool) -> dict[str, Any]:
+def normalize_config(path: Path, require_roots: bool, home: Path) -> dict[str, Any]:
     data = load_yaml(path)
     if not isinstance(data, dict):
         fail("config must be a YAML mapping")
@@ -230,15 +264,20 @@ def normalize_config(path: Path, require_roots: bool) -> dict[str, Any]:
             normalized["priority"] = priority
         normalized_bases.append(normalized)
 
-    return {
+    normalized_config = {
         "config_path": str(path),
         "version": 1,
         "bases": normalized_bases,
+        "audit": default_audit(home),
+        "_audit_declared": "audit" in data,
     }
+    if "audit" in data:
+        normalized_config["audit"] = normalize_audit(data["audit"], "audit", path.parent, home)
+    return normalized_config
 
 
-def merge_configs(paths: list[Path], require_roots: bool) -> dict[str, Any]:
-    normalized_configs = [normalize_config(path, require_roots) for path in paths]
+def merge_configs(paths: list[Path], require_roots: bool, home: Path) -> dict[str, Any]:
+    normalized_configs = [normalize_config(path, require_roots, home) for path in paths]
     merged_bases: list[dict[str, Any]] = []
     seen_names: set[str] = set()
     for config in normalized_configs:
@@ -247,11 +286,17 @@ def merge_configs(paths: list[Path], require_roots: bool) -> dict[str, Any]:
                 continue
             seen_names.add(base["name"])
             merged_bases.append(base)
+    audit = default_audit(home)
+    for config in normalized_configs:
+        if config["_audit_declared"]:
+            audit = config["audit"]
+            break
     return {
         "config_path": str(paths[0]),
         "config_paths": [str(path) for path in paths],
         "version": 1,
         "bases": merged_bases,
+        "audit": audit,
     }
 
 
@@ -266,7 +311,7 @@ def load_config(
     for path in paths:
         if not path.is_file():
             fail(f"config does not exist: {path}")
-    return merge_configs(paths, require_roots)
+    return merge_configs(paths, require_roots, home)
 
 
 def parse_args() -> argparse.Namespace:

--- a/active/mem/scripts/mem.py
+++ b/active/mem/scripts/mem.py
@@ -197,7 +197,7 @@ def main() -> None:
     if command == "context":
         from context import main as run_context
 
-        run_context(command_args, command_argv=[*getattr(sys, "orig_argv", [sys.executable, *sys.argv])])
+        run_context(command_args)
         return
     if command == "schema":
         run_schema(prepare_schema_args(command_args))

--- a/active/mem/scripts/mem.py
+++ b/active/mem/scripts/mem.py
@@ -170,6 +170,7 @@ def usage() -> str:
     return """usage:
   mem.py config show [load_config options]
   mem.py route [route options]
+  mem.py context lookup [context options]
   mem.py schema <list|show|describe|validate|materialize> [schema options]
 
 Managed schema materialization:
@@ -193,6 +194,11 @@ def main() -> None:
         run_python("load_config.py", command_args[1:])
     if command == "route":
         run_python("route.py", command_args)
+    if command == "context":
+        from context import main as run_context
+
+        run_context(command_args, command_argv=[*getattr(sys, "orig_argv", [sys.executable, *sys.argv])])
+        return
     if command == "schema":
         run_schema(prepare_schema_args(command_args))
     fail(f"unknown command: {command}")

--- a/active/mem/scripts/route.py
+++ b/active/mem/scripts/route.py
@@ -8,6 +8,7 @@ import fnmatch
 import json
 import re
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -78,7 +79,7 @@ def score_base(
     *,
     query: str,
     cwd: Path,
-    source: str | None,
+    source: str | Sequence[str] | None,
     artifact_kind: str | None,
     target: str | None,
 ) -> tuple[int, list[str]]:
@@ -120,9 +121,13 @@ def score_base(
             score += 70
             reasons.append(f"cwd:{pattern}")
 
-    if source:
+    if isinstance(source, str):
+        sources = [source]
+    else:
+        sources = list(source or [])
+    if sources:
         for pattern in match.get("source_globs", []):
-            if fnmatch.fnmatch(source, pattern):
+            if any(fnmatch.fnmatch(candidate, pattern) for candidate in sources):
                 score += 70
                 reasons.append(f"source:{pattern}")
 
@@ -143,7 +148,7 @@ def route(
     *,
     query: str,
     cwd: Path,
-    source: str | None = None,
+    source: str | Sequence[str] | None = None,
     artifact_kind: str | None = None,
     target: str | None = None,
 ) -> dict[str, Any]:

--- a/active/mem/scripts/tests/test_audit_trace.py
+++ b/active/mem/scripts/tests/test_audit_trace.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib
+import fcntl
 import json
 import multiprocessing
 import os
@@ -218,6 +219,25 @@ class AuditTraceWriterTests(unittest.TestCase):
         self.assertEqual(stat.S_IMODE(first_path.parent.stat().st_mode), 0o700)
         self.assertEqual(stat.S_IMODE(first_path.stat().st_mode), 0o600)
 
+    def test_lock_acquisition_times_out_with_an_explicit_error(self) -> None:
+        writer = audit_trace.AuditTraceWriter(self.root, SESSION_ID)
+        writer._ensure_root()
+        lock_dir = self.root / ".locks"
+        writer._ensure_directory(lock_dir)
+        lock_path = lock_dir / f"{SESSION_ID}.lock"
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            with (
+                mock.patch.object(audit_trace, "LOCK_TIMEOUT_SECONDS", 0.02),
+                mock.patch.object(audit_trace, "LOCK_RETRY_SECONDS", 0.005),
+                self.assertRaisesRegex(audit_trace.AuditTraceError, "timed out acquiring"),
+            ):
+                audit_trace.AuditTraceWriter(self.root, SESSION_ID).prepare()
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
     def test_write_normalizes_command_and_merges_duplicate_attempts(self) -> None:
         writer = audit_trace.AuditTraceWriter(self.root, SESSION_ID)
         first = make_record(duration_ms=10, status="unmatched")
@@ -264,8 +284,13 @@ class AuditTraceWriterTests(unittest.TestCase):
             process.join(timeout=15)
             self.assertEqual(process.exitcode, 0)
 
-        expected = self.root / "2026" / "08" / "06" / f"{SESSION_ID}.jsonl"
-        records = self.read_records(expected)
+        traces = sorted(
+            self.root.glob(
+                f"[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9]/{SESSION_ID}.jsonl"
+            )
+        )
+        self.assertEqual(len(traces), 1)
+        records = self.read_records(traces[0])
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]["occurrence_count"], 8)
         self.assertEqual(len(records[0]["attempts"]), 8)

--- a/active/mem/scripts/tests/test_audit_trace.py
+++ b/active/mem/scripts/tests/test_audit_trace.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Focused tests for secure mem audit trace persistence."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import multiprocessing
+import os
+import re
+import stat
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+
+
+TEST_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = TEST_DIR.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+audit_trace = importlib.import_module("audit_trace")
+
+
+SESSION_ID = "019fa5de-c89c-7402-ad74-2978a02a04ad"
+PACIFIC = timezone(timedelta(hours=-7))
+
+
+def make_record(
+    *,
+    query: str = "gateway authentication",
+    started: datetime | None = None,
+    duration_ms: int = 87,
+    status: str = "matched",
+    source_scopes: list[str] | None = None,
+) -> dict[str, object]:
+    started = started or datetime(2026, 8, 6, 9, 2, tzinfo=PACIFIC)
+    finished = started + timedelta(milliseconds=duration_ms)
+    started_at = audit_trace.timestamp_ms(started)
+    finished_at = audit_trace.timestamp_ms(finished)
+    command = {
+        "argv": [
+            "python3",
+            "./scripts/mem.py",
+            "context",
+            "lookup",
+            "--query",
+            query,
+            "--target",
+            "claw",
+        ],
+        "command": "caller supplied text is normalized",
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "duration_ms": duration_ms,
+    }
+    operation = {
+        "name": "route",
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "duration_ms": duration_ms,
+    }
+    attempt = {
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "duration_ms": duration_ms,
+        "command_timings": [
+            {
+                "command_index": 0,
+                "started_at": started_at,
+                "finished_at": finished_at,
+                "duration_ms": duration_ms,
+            }
+        ],
+        "operation_timings": [operation.copy()],
+        "status": status,
+    }
+    return {
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "duration_ms": duration_ms,
+        "query": query,
+        "commands": [command],
+        "operations": [operation],
+        "attempts": [attempt],
+        "hierarchy": [
+            {
+                "path": "/knowledge/pkg/clawgateway",
+                "schema": "pkg",
+                "decision": "searched",
+                "reason": "The selected base contains the requested package.",
+            }
+        ],
+        "selection": {
+            "tier": "explicit",
+            "bases": ["claw"],
+            "reasons": ["explicit base name"],
+        },
+        "source_scopes": source_scopes or [],
+        "fallback": {"used": False, "paths": [], "reason": "Managed match."},
+        "status": status,
+        "matched_paths": ["/knowledge/pkg/clawgateway/ref/authentication.md"],
+    }
+
+
+def concurrent_write(trace_root: str, index: int) -> None:
+    record = make_record(
+        started=datetime(2026, 8, 6, 9, 2, tzinfo=PACIFIC)
+        + timedelta(seconds=index),
+        duration_ms=index + 1,
+        status=f"attempt-{index}",
+    )
+    audit_trace.AuditTraceWriter(trace_root, SESSION_ID).write(record)
+
+
+class AuditTraceHelperTests(unittest.TestCase):
+    def test_session_id_is_explicitly_validated_and_canonicalized(self) -> None:
+        self.assertEqual(
+            audit_trace.validate_session_id(SESSION_ID.upper()),
+            SESSION_ID,
+        )
+        for invalid in ("", "../conversation", "not-a-uuid"):
+            with self.subTest(invalid=invalid), self.assertRaises(audit_trace.AuditTraceError):
+                audit_trace.validate_session_id(invalid)
+
+    def test_timestamp_duration_and_shell_helpers(self) -> None:
+        moment = datetime(2026, 8, 6, 9, 2, 0, 123456, tzinfo=PACIFIC)
+        self.assertEqual(audit_trace.timestamp_ms(moment), "2026-08-06T09:02:00.123-07:00")
+        self.assertEqual(audit_trace.elapsed_ms(10.0, 10.0874), 87)
+        self.assertEqual(
+            audit_trace.shell_quote_argv(["mem", "two words", "", "$TOKEN", "it's"]),
+            "mem 'two words' '' '$TOKEN' 'it'\"'\"'s'",
+        )
+        with self.assertRaises(audit_trace.AuditTraceError):
+            audit_trace.timestamp_ms(moment.replace(tzinfo=None))
+        with self.assertRaises(audit_trace.AuditTraceError):
+            audit_trace.elapsed_ms(2.0, 1.0)
+        rollback = audit_trace.timing_snapshot(
+            started_at=moment,
+            finished_at=moment - timedelta(seconds=1),
+            start_monotonic=10.0,
+            finished_monotonic=10.005,
+        )
+        self.assertEqual(rollback["duration_ms"], 5)
+
+    def test_fingerprint_is_canonical_and_covers_only_logical_lookup_fields(self) -> None:
+        arguments = {
+            "session_id": SESSION_ID,
+            "query": "auth",
+            "commands": [["mem", "lookup", "auth"]],
+            "selected_bases": ["claw"],
+            "hierarchy_paths": ["/knowledge/claw"],
+            "source_scopes": ["codex/claw/**"],
+        }
+        first = audit_trace.canonical_lookup_id(**arguments)
+        second = audit_trace.canonical_lookup_id(**dict(reversed(list(arguments.items()))))
+        self.assertEqual(first, second)
+        self.assertRegex(first, r"^sha256:[0-9a-f]{64}$")
+
+        for field, replacement in (
+            ("query", "different"),
+            ("commands", [["mem", "lookup", "different"]]),
+            ("selected_bases", ["other"]),
+            ("hierarchy_paths", ["/knowledge/other"]),
+            ("source_scopes", ["other/**"]),
+        ):
+            changed = dict(arguments)
+            changed[field] = replacement
+            with self.subTest(field=field):
+                self.assertNotEqual(first, audit_trace.canonical_lookup_id(**changed))
+
+
+class AuditTraceWriterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name) / "traces"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def read_records(self, path: Path) -> list[dict[str, object]]:
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+    def test_prepare_pins_first_local_date_and_secures_paths(self) -> None:
+        writer = audit_trace.AuditTraceWriter(self.root, SESSION_ID)
+        first_day = datetime(2026, 8, 6, 23, 59, tzinfo=PACIFIC)
+        with writer.locked(now=first_day) as locked_writer:
+            self.assertIs(locked_writer, writer)
+            first_path = writer.trace_path
+            self.assertEqual(
+                first_path.relative_to(writer.trace_root),
+                Path("2026/08/06") / f"{SESSION_ID}.jsonl",
+            )
+            self.assertTrue(first_path.is_file())
+
+        next_day = first_day + timedelta(minutes=2)
+        with audit_trace.AuditTraceWriter(self.root, SESSION_ID).locked(now=next_day) as second:
+            self.assertEqual(second.trace_path, first_path)
+
+        for directory in (
+            self.root,
+            self.root / ".locks",
+            self.root / "2026",
+            self.root / "2026" / "08",
+            self.root / "2026" / "08" / "06",
+        ):
+            self.assertEqual(stat.S_IMODE(directory.stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(first_path.stat().st_mode), 0o600)
+        lock_path = self.root / ".locks" / f"{SESSION_ID}.lock"
+        self.assertEqual(stat.S_IMODE(lock_path.stat().st_mode), 0o600)
+
+        first_path.parent.chmod(0o755)
+        first_path.chmod(0o644)
+        with audit_trace.AuditTraceWriter(self.root, SESSION_ID).locked(now=next_day):
+            pass
+        self.assertEqual(stat.S_IMODE(first_path.parent.stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(first_path.stat().st_mode), 0o600)
+
+    def test_write_normalizes_command_and_merges_duplicate_attempts(self) -> None:
+        writer = audit_trace.AuditTraceWriter(self.root, SESSION_ID)
+        first = make_record(duration_ms=10, status="unmatched")
+        second = make_record(
+            started=datetime(2026, 8, 6, 9, 3, tzinfo=PACIFIC),
+            duration_ms=20,
+            status="matched",
+        )
+        path = writer.write(first)
+        self.assertEqual(writer.write(second), path)
+
+        records = self.read_records(path)
+        self.assertEqual(len(records), 1)
+        record = records[0]
+        self.assertEqual(record["occurrence_count"], 2)
+        self.assertEqual(record["duration_ms"], 30)
+        self.assertEqual(record["started_at"], first["started_at"])
+        self.assertEqual(record["finished_at"], second["finished_at"])
+        self.assertEqual(record["status"], "matched")
+        self.assertEqual(len(record["attempts"]), 2)
+        self.assertEqual(record["operations"], second["operations"])
+        self.assertEqual(
+            record["commands"][0]["command"],
+            "python3 ./scripts/mem.py context lookup --query 'gateway authentication' --target claw",
+        )
+
+    def test_distinct_logical_lookups_are_separate_json_lines(self) -> None:
+        writer = audit_trace.AuditTraceWriter(self.root, SESSION_ID)
+        path = writer.write(make_record(query="authentication"))
+        writer.write(make_record(query="authorization"))
+        records = self.read_records(path)
+        self.assertEqual([record["query"] for record in records], ["authentication", "authorization"])
+        self.assertNotEqual(records[0]["lookup_id"], records[1]["lookup_id"])
+
+    def test_concurrent_duplicate_writes_lose_no_attempts(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        processes = [
+            context.Process(target=concurrent_write, args=(str(self.root), index))
+            for index in range(8)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=15)
+            self.assertEqual(process.exitcode, 0)
+
+        expected = self.root / "2026" / "08" / "06" / f"{SESSION_ID}.jsonl"
+        records = self.read_records(expected)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["occurrence_count"], 8)
+        self.assertEqual(len(records[0]["attempts"]), 8)
+        self.assertEqual(records[0]["duration_ms"], sum(range(1, 9)))
+
+    def test_containment_rejects_date_directory_symlink(self) -> None:
+        outside = Path(self._tmp.name) / "outside"
+        outside.mkdir()
+        self.root.mkdir()
+        (self.root / "2026").symlink_to(outside, target_is_directory=True)
+        writer = audit_trace.AuditTraceWriter(self.root, SESSION_ID)
+        with self.assertRaisesRegex(audit_trace.AuditTraceError, "outside trace root"):
+            writer.prepare(now=datetime(2026, 8, 6, tzinfo=PACIFIC))
+        self.assertFalse((outside / "08").exists())
+
+    def test_invalid_session_fails_before_touching_trace_root(self) -> None:
+        os.environ["CODEX_THREAD_ID"] = SESSION_ID
+        try:
+            with self.assertRaisesRegex(audit_trace.AuditTraceError, "valid UUID"):
+                audit_trace.AuditTraceWriter(self.root, "../unsafe")
+        finally:
+            os.environ.pop("CODEX_THREAD_ID", None)
+        self.assertFalse(self.root.exists())
+
+    def test_malformed_existing_trace_is_an_explicit_prepare_error(self) -> None:
+        path = self.root / "2026" / "08" / "06" / f"{SESSION_ID}.jsonl"
+        path.parent.mkdir(parents=True)
+        path.write_text("not json\n", encoding="utf-8")
+        writer = audit_trace.AuditTraceWriter(self.root, SESSION_ID)
+        with self.assertRaisesRegex(audit_trace.AuditTraceError, "invalid JSON"):
+            writer.prepare(now=datetime(2026, 8, 7, tzinfo=PACIFIC))
+
+    def test_failed_atomic_replace_preserves_existing_trace(self) -> None:
+        writer = audit_trace.AuditTraceWriter(self.root, SESSION_ID)
+        path = writer.write(make_record(query="first"))
+        original = path.read_bytes()
+        with mock.patch.object(audit_trace.os, "replace", side_effect=OSError("denied")):
+            with self.assertRaisesRegex(audit_trace.AuditTraceError, "atomically update"):
+                writer.write(make_record(query="second"))
+        self.assertEqual(path.read_bytes(), original)
+        self.assertEqual(list(path.parent.glob(".*.tmp")), [])
+
+    def test_record_validation_reports_unsafe_or_incomplete_data(self) -> None:
+        record = make_record()
+        record["started_at"] = "2026-08-06T09:02:00"
+        with self.assertRaisesRegex(audit_trace.AuditTraceError, "timezone-aware"):
+            audit_trace.AuditTraceWriter(self.root, SESSION_ID).write(record)
+
+        record = make_record()
+        record["attempts"][0]["command_timings"] = []
+        with self.assertRaisesRegex(audit_trace.AuditTraceError, "cover each command"):
+            audit_trace.AuditTraceWriter(self.root, SESSION_ID).write(record)
+
+        record = make_record()
+        del record["source_scopes"]
+        with self.assertRaisesRegex(audit_trace.AuditTraceError, "source_scopes is required"):
+            audit_trace.AuditTraceWriter(self.root, SESSION_ID).write(record)
+
+        record = make_record()
+        record["occurrence_count"] = True
+        with self.assertRaisesRegex(audit_trace.AuditTraceError, "nonnegative integer"):
+            audit_trace.AuditTraceWriter(self.root, SESSION_ID).write(record)
+
+    def test_existing_record_version_and_fingerprint_are_revalidated(self) -> None:
+        writer = audit_trace.AuditTraceWriter(self.root, SESSION_ID)
+        path = writer.write(make_record())
+        record = self.read_records(path)[0]
+        record["version"] = 2
+        path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(audit_trace.AuditTraceError, "unsupported version"):
+            audit_trace.AuditTraceWriter(self.root, SESSION_ID).prepare()
+
+        record["version"] = 1
+        record["lookup_id"] = "sha256:" + "0" * 64
+        path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(audit_trace.AuditTraceError, "canonical fingerprint"):
+            audit_trace.AuditTraceWriter(self.root, SESSION_ID).prepare()
+
+    def test_existing_record_aggregate_and_outcome_invariants_are_revalidated(self) -> None:
+        mutations = (
+            (
+                lambda record: record.__setitem__("duration_ms", record["duration_ms"] + 1),
+                "sum of attempt durations",
+            ),
+            (
+                lambda record: record.__setitem__("started_at", "2026-08-06T08:00:00.000-07:00"),
+                "first attempt start",
+            ),
+            (
+                lambda record: record.__setitem__("finished_at", "2026-08-06T10:00:00.000-07:00"),
+                "latest attempt finish",
+            ),
+            (
+                lambda record: record.__setitem__("operations", []),
+                "latest attempt",
+            ),
+            (
+                lambda record: record.pop("fallback"),
+                "fallback must be a mapping",
+            ),
+            (
+                lambda record: record.__setitem__("status", "different"),
+                "latest attempt status",
+            ),
+            (
+                lambda record: record.__setitem__("matched_paths", "not-a-list"),
+                "matched_paths must be a sequence",
+            ),
+        )
+        for mutate, message in mutations:
+            with self.subTest(message=message):
+                case_root = self.root / re.sub(r"[^a-z]+", "-", message).strip("-")
+                writer = audit_trace.AuditTraceWriter(case_root, SESSION_ID)
+                path = writer.write(make_record())
+                record = self.read_records(path)[0]
+                mutate(record)
+                path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+                with self.assertRaisesRegex(audit_trace.AuditTraceError, message):
+                    audit_trace.AuditTraceWriter(case_root, SESSION_ID).prepare()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/active/mem/scripts/tests/test_context.py
+++ b/active/mem/scripts/tests/test_context.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""End-to-end tests for read-only context lookup audit tracing."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+
+TEST_DIR = Path(__file__).resolve().parent
+MEM_PATH = TEST_DIR.parents[0] / "mem.py"
+SESSION_ID = "019fa5de-c89c-7402-ad74-2978a02a04ad"
+
+
+class ContextLookupTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.base = self.root / "knowledge"
+        self.base.mkdir()
+        self.source = self.root / "source"
+        self.source.mkdir()
+        self.trace_root = self.root / "traces"
+        self.schema = self.root / "schema.yaml"
+        self.schema.write_text(
+            textwrap.dedent(
+                """
+                version: 1.0
+                schema:
+                  pkg:
+                    description: Package gateway authentication knowledge.
+                    children:
+                      ref:
+                        description: Authentication reference material.
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        self.config = self.root / ".mem.yaml"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def write_config(
+        self,
+        *,
+        enabled: bool,
+        bases: list[tuple[str, Path]] | None = None,
+        trace_root: Path | None = None,
+    ) -> None:
+        configured_bases = bases or [("docs", self.base)]
+        base_yaml = "\n".join(
+            textwrap.dedent(
+                f"""
+                  - name: {name}
+                    description: Durable package documentation.
+                    root: {root}
+                    path_style: directory
+                    schemas:
+                      - name: pkg
+                        path: {self.schema}
+                """
+            ).rstrip()
+            for name, root in configured_bases
+        )
+        chosen_root = trace_root or self.trace_root
+        self.config.write_text(
+            f"version: 1\naudit:\n  enabled: {str(enabled).lower()}\n"
+            f"  trace_root: {chosen_root}\nbases:\n{base_yaml}\n",
+            encoding="utf-8",
+        )
+
+    def run_lookup(
+        self,
+        query: str,
+        *extra: str,
+        session_id: str | None = SESSION_ID,
+        secret: str | None = None,
+        process_cwd: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.pop("CODEX_THREAD_ID", None)
+        if session_id is not None:
+            env["CODEX_THREAD_ID"] = session_id
+        if secret is not None:
+            env["UNRELATED_SECRET"] = secret
+        return subprocess.run(
+            [
+                "python3",
+                str(MEM_PATH),
+                "context",
+                "lookup",
+                "--query",
+                query,
+                "--config",
+                str(self.config),
+                *extra,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=env,
+            cwd=process_cwd,
+        )
+
+    def trace_files(self) -> list[Path]:
+        return sorted(self.trace_root.glob(f"[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9]/{SESSION_ID}.jsonl"))
+
+    def records(self) -> list[dict[str, object]]:
+        files = self.trace_files()
+        self.assertEqual(len(files), 1)
+        return [json.loads(line) for line in files[0].read_text(encoding="utf-8").splitlines() if line]
+
+    def test_disabled_lookup_creates_no_trace_and_does_not_require_session(self) -> None:
+        self.write_config(enabled=False)
+        (self.base / "authentication.md").write_text("gateway authentication\n", encoding="utf-8")
+
+        result = self.run_lookup("gateway authentication", session_id=None)
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(json.loads(result.stdout)["status"], "matched")
+        self.assertFalse(self.trace_root.exists())
+
+    def test_enabled_lookup_records_actual_command_hierarchy_and_timings(self) -> None:
+        self.write_config(enabled=True)
+        match = self.base / "authentication.md"
+        match.write_text("gateway authentication\n", encoding="utf-8")
+        secret = "must-not-appear-in-trace"
+
+        result = self.run_lookup("gateway authentication", "--target", "docs", secret=secret)
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        record = self.records()[0]
+        self.assertEqual(record["query"], "gateway authentication")
+        self.assertEqual(record["status"], "matched")
+        self.assertEqual(record["matched_paths"], [str(match.resolve())])
+        self.assertEqual([op["name"] for op in record["operations"]], [
+            "load_config",
+            "route",
+            "resolve_schemas",
+            "search_managed",
+        ])
+        command = record["commands"][0]
+        self.assertEqual(Path(command["argv"][0]).name, "python3")
+        self.assertEqual(command["argv"][1], str(MEM_PATH))
+        self.assertIn("'gateway authentication'", command["command"])
+        self.assertNotIn("context.py", command["command"])
+        self.assertNotIn(secret, json.dumps(record))
+        self.assertEqual(record["selection"]["tier"], "explicit")
+        self.assertEqual(record["hierarchy"][0]["path"], str(self.base.resolve()))
+        self.assertIn("sharing query terms", record["hierarchy"][0]["reason"])
+        for timing in [record, command, *record["operations"]]:
+            self.assertGreaterEqual(timing["duration_ms"], 0)
+            self.assertIsNotNone(datetime.fromisoformat(timing["started_at"]).tzinfo)
+            self.assertIsNotNone(datetime.fromisoformat(timing["finished_at"]).tzinfo)
+
+    def test_source_fallback_is_recorded_only_when_it_runs(self) -> None:
+        self.write_config(enabled=True)
+        source_match = self.source / "gateway.py"
+        source_match.write_text("authenticate gateway request\n", encoding="utf-8")
+
+        result = self.run_lookup(
+            "gateway authenticate",
+            "--target",
+            "docs",
+            "--source",
+            str(self.source),
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        record = self.records()[0]
+        self.assertEqual(record["status"], "matched")
+        self.assertEqual(record["matched_paths"], [str(source_match.resolve())])
+        self.assertTrue(record["fallback"]["used"])
+        self.assertEqual(record["fallback"]["paths"], [str(self.source.resolve())])
+        self.assertEqual(record["operations"][-1]["name"], "search_source")
+        self.assertEqual(record["hierarchy"][-1]["schema"], "source")
+
+    def test_ambiguous_lookup_records_status_without_search_stages(self) -> None:
+        other = self.root / "other"
+        other.mkdir()
+        self.write_config(enabled=True, bases=[("docs", self.base), ("other", other)])
+
+        result = self.run_lookup("unrelated")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        record = self.records()[0]
+        self.assertEqual(record["status"], "ambiguous")
+        self.assertEqual(record["hierarchy"], [])
+        self.assertEqual([op["name"] for op in record["operations"]], ["load_config", "route"])
+
+    def test_every_repeatable_source_scope_can_influence_routing(self) -> None:
+        other = self.root / "other"
+        other.mkdir()
+        first_source = self.root / "first-source"
+        first_source.mkdir()
+        second_source = self.root / "second-source"
+        second_source.mkdir()
+        self.config.write_text(
+            textwrap.dedent(
+                f"""
+                version: 1
+                audit:
+                  enabled: true
+                  trace_root: {self.trace_root}
+                bases:
+                  - name: docs
+                    description: Durable package documentation.
+                    root: {self.base}
+                    schemas:
+                      - name: pkg
+                        path: {self.schema}
+                  - name: other
+                    description: Durable package documentation.
+                    root: {other}
+                    match:
+                      source_globs: ["second-source"]
+                    schemas:
+                      - name: pkg
+                        path: {self.schema}
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = self.run_lookup(
+            "not present",
+            "--source",
+            "first-source",
+            "--source",
+            "second-source",
+            process_cwd=self.root,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        output = json.loads(result.stdout)
+        self.assertEqual(output["selection"]["bases"], ["other"], msg=result.stdout)
+        self.assertEqual(output["status"], "unmatched")
+        record = self.records()[0]
+        self.assertEqual(record["selection"]["bases"], ["other"])
+        self.assertIn("source:second-source", record["selection"]["reasons"])
+
+    def test_failed_fallback_records_real_error_status(self) -> None:
+        self.write_config(enabled=True)
+        missing = self.root / "missing-source"
+
+        result = self.run_lookup(
+            "not present",
+            "--target",
+            "docs",
+            "--source",
+            str(missing),
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("search scope does not exist", result.stderr)
+        record = self.records()[0]
+        self.assertEqual(record["status"], "error")
+        self.assertEqual(record["operations"][-1]["name"], "search_source")
+
+    def test_missing_or_unsafe_session_fails_before_search(self) -> None:
+        self.write_config(enabled=True)
+        (self.base / "would-match.md").write_text("gateway authentication\n", encoding="utf-8")
+
+        for session_id in (None, "../not-a-session"):
+            with self.subTest(session_id=session_id):
+                result = self.run_lookup("gateway authentication", session_id=session_id)
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("audit session ID", result.stderr)
+
+        self.assertFalse(self.trace_root.exists())
+
+    def test_duplicate_and_distinct_logical_lookups_are_merged_correctly(self) -> None:
+        self.write_config(enabled=True)
+        (self.base / "authentication.md").write_text("gateway authentication tokens\n", encoding="utf-8")
+
+        first = self.run_lookup("gateway authentication", "--target", "docs")
+        second = self.run_lookup("gateway authentication", "--target", "docs")
+        distinct = self.run_lookup("authentication tokens", "--target", "docs")
+
+        self.assertEqual((first.returncode, second.returncode, distinct.returncode), (0, 0, 0))
+        records = self.records()
+        self.assertEqual(len(records), 2)
+        repeated = next(record for record in records if record["query"] == "gateway authentication")
+        self.assertEqual(repeated["occurrence_count"], 2)
+        self.assertEqual(len(repeated["attempts"]), 2)
+        self.assertEqual(
+            repeated["duration_ms"],
+            sum(attempt["duration_ms"] for attempt in repeated["attempts"]),
+        )
+
+    def test_unwritable_trace_destination_fails_closed(self) -> None:
+        bad_root = self.root / "trace-file"
+        bad_root.write_text("not a directory\n", encoding="utf-8")
+        self.write_config(enabled=True, trace_root=bad_root)
+        (self.base / "authentication.md").write_text("gateway authentication\n", encoding="utf-8")
+
+        result = self.run_lookup("gateway authentication", "--target", "docs")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("audit trace failed", result.stderr)
+        self.assertEqual(bad_root.read_text(encoding="utf-8"), "not a directory\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/active/mem/scripts/tests/test_context.py
+++ b/active/mem/scripts/tests/test_context.py
@@ -3,18 +3,24 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import textwrap
 import unittest
 from datetime import datetime
 from pathlib import Path
+from unittest import mock
 
 
 TEST_DIR = Path(__file__).resolve().parent
 MEM_PATH = TEST_DIR.parents[0] / "mem.py"
+SCRIPT_DIR = MEM_PATH.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+context_module = importlib.import_module("context")
 SESSION_ID = "019fa5de-c89c-7402-ad74-2978a02a04ad"
 
 
@@ -216,6 +222,69 @@ class ContextLookupTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertEqual(self.records()[0]["matched_paths"], [str(text_match.resolve())])
+
+    def test_source_search_rejects_file_replaced_by_symlink_before_open(self) -> None:
+        outside = self.root / "outside.txt"
+        outside.write_text("outside secret\n", encoding="utf-8")
+        victim = self.source / "victim.txt"
+        victim.write_text("safe text\n", encoding="utf-8")
+        original_open = context_module.os.open
+        replaced = False
+
+        def replace_then_open(
+            path: str | Path,
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            nonlocal replaced
+            if dir_fd is not None and os.fspath(path) == victim.name and not replaced:
+                victim.unlink()
+                victim.symlink_to(outside)
+                replaced = True
+            if dir_fd is None:
+                return original_open(path, flags, mode)
+            return original_open(path, flags, mode, dir_fd=dir_fd)
+
+        with mock.patch.object(context_module.os, "open", side_effect=replace_then_open):
+            matches = context_module.search_scope(self.source, "outside secret")
+
+        self.assertTrue(replaced)
+        self.assertEqual(matches, [])
+
+    def test_source_search_rejects_directory_replaced_by_symlink_before_open(self) -> None:
+        outside = self.root / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("outside secret\n", encoding="utf-8")
+        nested = self.source / "nested"
+        nested.mkdir()
+        (nested / "safe.txt").write_text("safe text\n", encoding="utf-8")
+        original_open = context_module.os.open
+        replaced = False
+
+        def replace_then_open(
+            path: str | Path,
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            nonlocal replaced
+            if dir_fd is not None and os.fspath(path) == nested.name and not replaced:
+                (nested / "safe.txt").unlink()
+                nested.rmdir()
+                nested.symlink_to(outside, target_is_directory=True)
+                replaced = True
+            if dir_fd is None:
+                return original_open(path, flags, mode)
+            return original_open(path, flags, mode, dir_fd=dir_fd)
+
+        with mock.patch.object(context_module.os, "open", side_effect=replace_then_open):
+            matches = context_module.search_scope(self.source, "outside secret")
+
+        self.assertTrue(replaced)
+        self.assertEqual(matches, [])
 
     def test_ambiguous_lookup_records_status_without_search_stages(self) -> None:
         other = self.root / "other"

--- a/active/mem/scripts/tests/test_context.py
+++ b/active/mem/scripts/tests/test_context.py
@@ -128,6 +128,19 @@ class ContextLookupTests(unittest.TestCase):
         self.assertEqual(json.loads(result.stdout)["status"], "matched")
         self.assertFalse(self.trace_root.exists())
 
+    def test_empty_query_is_rejected_without_searching(self) -> None:
+        self.write_config(enabled=True)
+        (self.base / "would-match.md").write_text("anything\n", encoding="utf-8")
+
+        result = self.run_lookup("   ", "--target", "docs")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("query must not be empty", result.stderr)
+        record = self.records()[0]
+        self.assertEqual(record["status"], "error")
+        self.assertEqual([op["name"] for op in record["operations"]], ["load_config"])
+        self.assertEqual(record["matched_paths"], [])
+
     def test_enabled_lookup_records_actual_command_hierarchy_and_timings(self) -> None:
         self.write_config(enabled=True)
         match = self.base / "authentication.md"
@@ -182,6 +195,27 @@ class ContextLookupTests(unittest.TestCase):
         self.assertEqual(record["fallback"]["paths"], [str(self.source.resolve())])
         self.assertEqual(record["operations"][-1]["name"], "search_source")
         self.assertEqual(record["hierarchy"][-1]["schema"], "source")
+
+    def test_source_search_streams_text_and_skips_large_or_binary_bodies(self) -> None:
+        self.write_config(enabled=True)
+        text_match = self.source / "small.txt"
+        text_match.write_text("needle\nphrase\n", encoding="utf-8")
+        (self.source / "large.dat").write_text(
+            "needle phrase\n" + "x" * (2 * 1024 * 1024),
+            encoding="utf-8",
+        )
+        (self.source / "binary.dat").write_bytes(b"needle phrase\x00payload")
+
+        result = self.run_lookup(
+            "needle phrase",
+            "--target",
+            "docs",
+            "--source",
+            str(self.source),
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(self.records()[0]["matched_paths"], [str(text_match.resolve())])
 
     def test_ambiguous_lookup_records_status_without_search_stages(self) -> None:
         other = self.root / "other"
@@ -257,6 +291,8 @@ class ContextLookupTests(unittest.TestCase):
             "--target",
             "docs",
             "--source",
+            str(self.source),
+            "--source",
             str(missing),
         )
 
@@ -265,6 +301,11 @@ class ContextLookupTests(unittest.TestCase):
         record = self.records()[0]
         self.assertEqual(record["status"], "error")
         self.assertEqual(record["operations"][-1]["name"], "search_source")
+        self.assertEqual(record["fallback"]["paths"], [str(self.source.resolve())])
+        self.assertEqual(
+            [entry["path"] for entry in record["hierarchy"] if entry["schema"] == "source"],
+            [str(self.source.resolve())],
+        )
 
     def test_missing_or_unsafe_session_fails_before_search(self) -> None:
         self.write_config(enabled=True)

--- a/active/mem/scripts/tests/test_load_config.py
+++ b/active/mem/scripts/tests/test_load_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import site
 import subprocess
 import tempfile
 import textwrap
@@ -315,12 +316,24 @@ class LoadConfigTests(unittest.TestCase):
             """
         )
 
-        result = self.run_loader()
+        env = os.environ.copy()
+        home = self.root / "env-home"
+        env["HOME"] = str(home)
+        env["PYTHONPATH"] = os.pathsep.join(
+            path for path in (site.getusersitepackages(), env.get("PYTHONPATH")) if path
+        )
+        result = subprocess.run(
+            ["python3", str(SCRIPT_PATH), "--config", str(self.config)],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=env,
+        )
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertEqual(
             json.loads(result.stdout)["audit"]["trace_root"],
-            str((Path.home() / ".config" / "mem" / "custom-traces").resolve()),
+            str((home / ".config" / "mem" / "custom-traces").resolve()),
         )
 
     def test_invalid_audit_fields_are_rejected(self) -> None:

--- a/active/mem/scripts/tests/test_load_config.py
+++ b/active/mem/scripts/tests/test_load_config.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import tempfile
 import textwrap
@@ -226,6 +227,157 @@ class LoadConfigTests(unittest.TestCase):
         self.assertEqual(base["priority"], 25)
         self.assertEqual(base["match"]["topics"], ["configuration"])
 
+    def test_audit_defaults_are_exposed(self) -> None:
+        self.write_config(
+            f"""
+            version: 1
+            bases:
+              - name: docs
+                description: Durable documentation notes.
+                root: {self.base}
+                schemas:
+                  - name: tool
+            """
+        )
+
+        result = self.run_loader("--home", str(self.root / "home"))
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        data = json.loads(result.stdout)
+        self.assertEqual(
+            data["audit"],
+            {
+                "enabled": False,
+                "trace_root": str((self.root / "home" / ".config" / "mem" / "traces").resolve()),
+            },
+        )
+
+    def test_audit_is_normalized(self) -> None:
+        trace_root = self.root / "custom-traces"
+        self.write_config(
+            f"""
+            version: 1
+            audit:
+              enabled: true
+              trace_root: {trace_root}
+            bases:
+              - name: docs
+                description: Durable documentation notes.
+                root: {self.base}
+                schemas:
+                  - name: tool
+            """
+        )
+
+        result = self.run_loader()
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout)["audit"],
+            {"enabled": True, "trace_root": str(trace_root.resolve())},
+        )
+
+    def test_relative_audit_trace_root_is_resolved_from_config(self) -> None:
+        self.write_config(
+            f"""
+            version: 1
+            audit:
+              trace_root: traces
+            bases:
+              - name: docs
+                description: Durable documentation notes.
+                root: {self.base}
+                schemas:
+                  - name: tool
+            """
+        )
+
+        result = self.run_loader()
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout)["audit"],
+            {"enabled": False, "trace_root": str((self.root / "traces").resolve())},
+        )
+
+    def test_audit_trace_root_expands_home_environment_variable(self) -> None:
+        self.write_config(
+            f"""
+            version: 1
+            audit:
+              trace_root: $HOME/.config/mem/custom-traces
+            bases:
+              - name: docs
+                description: Durable documentation notes.
+                root: {self.base}
+                schemas:
+                  - name: tool
+            """
+        )
+
+        result = self.run_loader()
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout)["audit"]["trace_root"],
+            str((Path.home() / ".config" / "mem" / "custom-traces").resolve()),
+        )
+
+    def test_invalid_audit_fields_are_rejected(self) -> None:
+        for audit, message in (
+            ("true", "audit must be a mapping"),
+            ("{enabled: 1}", "audit.enabled must be a boolean"),
+            ("{trace_root: ''}", "audit.trace_root must be a non-empty string"),
+            ("{unknown: true}", "audit has unsupported key(s): unknown"),
+        ):
+            with self.subTest(audit=audit):
+                self.write_config(
+                    f"""
+                    version: 1
+                    audit: {audit}
+                    bases:
+                      - name: docs
+                        description: Durable documentation notes.
+                        root: {self.base}
+                        schemas:
+                          - name: tool
+                    """
+                )
+
+                result = self.run_loader()
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(message, result.stderr)
+
+    def test_audit_trace_root_rejects_unresolved_environment_variable(self) -> None:
+        self.write_config(
+            f"""
+            version: 1
+            audit:
+              enabled: true
+              trace_root: $MEM_AUDIT_ROOT_THAT_IS_NOT_SET/traces
+            bases:
+              - name: docs
+                description: Durable documentation notes.
+                root: {self.base}
+                schemas:
+                  - name: tool
+            """
+        )
+        env = os.environ.copy()
+        env.pop("MEM_AUDIT_ROOT_THAT_IS_NOT_SET", None)
+
+        result = subprocess.run(
+            ["python3", str(SCRIPT_PATH), "--config", str(self.config)],
+            text=True,
+            capture_output=True,
+            check=False,
+            env=env,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("contains an unresolved environment variable", result.stderr)
+
     def test_nearest_ancestor_and_home_configs_are_merged(self) -> None:
         project = self.root / "project"
         nested = project / "one" / "two"
@@ -339,6 +491,128 @@ class LoadConfigTests(unittest.TestCase):
         base = json.loads(result.stdout)["bases"][0]
         self.assertEqual(base["description"], "Local docs.")
         self.assertEqual(base["root"], str(local_base.resolve()))
+
+    def test_home_audit_is_inherited_when_nearest_does_not_declare_it(self) -> None:
+        project = self.root / "project"
+        home = self.root / "home"
+        project.mkdir()
+        home.mkdir()
+        (project / ".mem.yaml").write_text(
+            textwrap.dedent(
+                f"""
+                version: 1
+                bases:
+                  - name: project
+                    description: Project notes.
+                    root: {self.base}
+                    schemas:
+                      - name: tool
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        (home / ".mem.yaml").write_text(
+            textwrap.dedent(
+                f"""
+                version: 1
+                audit:
+                  enabled: true
+                  trace_root: {self.root / "home-traces"}
+                bases:
+                  - name: home
+                    description: Home notes.
+                    root: {self.base}
+                    schemas:
+                      - name: tool
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(SCRIPT_PATH),
+                "--cwd",
+                str(project),
+                "--home",
+                str(home),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout)["audit"],
+            {"enabled": True, "trace_root": str((self.root / "home-traces").resolve())},
+        )
+
+    def test_nearest_declared_audit_owns_entire_mapping(self) -> None:
+        project = self.root / "project"
+        home = self.root / "home"
+        project.mkdir()
+        home.mkdir()
+        (project / ".mem.yaml").write_text(
+            textwrap.dedent(
+                f"""
+                version: 1
+                audit:
+                  enabled: true
+                bases:
+                  - name: project
+                    description: Project notes.
+                    root: {self.base}
+                    schemas:
+                      - name: tool
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        (home / ".mem.yaml").write_text(
+            textwrap.dedent(
+                f"""
+                version: 1
+                audit:
+                  trace_root: {self.root / "home-traces"}
+                bases:
+                  - name: home
+                    description: Home notes.
+                    root: {self.base}
+                    schemas:
+                      - name: tool
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(SCRIPT_PATH),
+                "--cwd",
+                str(project),
+                "--home",
+                str(home),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout)["audit"],
+            {
+                "enabled": True,
+                "trace_root": str((home / ".config" / "mem" / "traces").resolve()),
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/docs/specs/active/2026-08-06-mem-audit-traces.md
+++ b/docs/specs/active/2026-08-06-mem-audit-traces.md
@@ -7,7 +7,7 @@ last_refreshed_by: 019fd474-e957-75e3-8610-647bebd4a0bb
 # Feature Spec: Mem Audit Trace Format
 
 **Date:** 2026-08-06
-**Status:** Planning
+**Status:** Completed
 **Owner:** Public `mem` skill maintainers
 
 ## Problem and Decision
@@ -26,7 +26,8 @@ operator documentation.
 
 **Does not change:** Base routing precedence, managed knowledge placement,
 schema semantics, source files, or existing behavior while audit is disabled.
-This document specifies the feature; it does not implement it.
+The shipped implementation lives in `scripts/audit_trace.py`,
+`scripts/load_config.py`, and `scripts/context.py`.
 
 ## Contract
 
@@ -125,17 +126,19 @@ Each nonempty line is one independent UTF-8 JSON object:
   ],
   "selection": {"tier": "explicit", "bases": ["claw"], "reasons": ["explicit base name"]},
   "hierarchy": [
-    {"path": "/Users/kevinlin/code/openclaw/.mem/main/pkg/clawgateway", "schema": "pkg", "decision": "searched",
+    {"path": "/absolute/project/.mem/main/pkg/clawgateway", "schema": "pkg", "decision": "searched",
      "reason": "The gateway query matches the package knowledge hierarchy."}
   ],
   "fallback": {"used": false, "paths": [], "reason": "Managed knowledge already contained a matching document."},
   "status": "matched",
-  "matched_paths": ["/Users/kevinlin/code/openclaw/.mem/main/pkg/clawgateway/ref/authentication.md"]
+  "matched_paths": ["/absolute/project/.mem/main/pkg/clawgateway/ref/authentication.md"],
+  "source_scopes": []
 }
 ```
 
 `started_at`, `finished_at`, `duration_ms`, `lookup_id`, `occurrence_count`,
-`query`, `commands`, `operations`, `attempts`, and `hierarchy` are required.
+`query`, `commands`, `operations`, `attempts`, `hierarchy`, and `source_scopes`
+are required.
 Every lookup, executed command, and operation has timezone-aware ISO 8601
 start/end timestamps with millisecond precision plus a nonnegative elapsed
 `duration_ms` measured from a monotonic clock. Top-level `started_at` is the

--- a/docs/specs/active/2026-08-06-mem-audit-traces.md
+++ b/docs/specs/active/2026-08-06-mem-audit-traces.md
@@ -1,0 +1,213 @@
+---
+title: Mem Audit Trace Format
+last_refreshed: 2026-08-06 09:15
+last_refreshed_by: 019fd474-e957-75e3-8610-647bebd4a0bb
+---
+
+# Feature Spec: Mem Audit Trace Format
+
+**Date:** 2026-08-06
+**Status:** Planning
+**Owner:** Public `mem` skill maintainers
+
+## Problem and Decision
+
+`mem` lookups currently return routing and search results but leave no durable
+record explaining which conversation searched for what, which CLI commands
+actually ran, why particular knowledge hierarchies were inspected, or how long
+each operation took. Add an opt-in audit mode that maintains one trace file per
+conversation and one structured JSON Lines record per distinct logical lookup,
+merging repeated searches without losing their timing history.
+
+## Scope
+
+**Changes:** Configuration parsing, lookup tracing, the trace format, and
+operator documentation.
+
+**Does not change:** Base routing precedence, managed knowledge placement,
+schema semantics, source files, or existing behavior while audit is disabled.
+This document specifies the feature; it does not implement it.
+
+## Contract
+
+### Configuration
+
+Add an optional top-level `audit` mapping to `.mem.yaml`:
+
+```yaml
+audit:
+  enabled: true
+  trace_root: ~/.config/mem/traces
+```
+
+`enabled` is a boolean and defaults to `false`. `trace_root` is optional and
+defaults to `$HOME/.config/mem/traces`; expand `~` and environment variables and
+normalize it to an absolute directory. When multiple configs are merged, the
+nearest configuration that declares `audit` owns the entire audit mapping;
+otherwise inherit the home config's mapping. Invalid fields or types fail
+configuration validation. `config show` exposes the normalized audit settings.
+
+### Trace location and lifecycle
+
+For an audit-enabled lookup, write to:
+
+```text
+<trace_root>/<YYYY>/<MM>/<DD>/<conversation-session-id>.jsonl
+```
+
+For example:
+
+```text
+~/.config/mem/traces/2026/08/06/019fa5de-c89c-7402-ad74-2978a02a04ad.jsonl
+```
+
+The date uses the user's local timezone when the conversation's first audited
+lookup starts. Later searches reuse that same session file, including after
+midnight; one conversation must never create another trace file under a new
+date. The session ID must come from the active conversation and be validated as
+a UUID; never use an inferred filename, traversal segment, or unrelated
+conversation. Create trace directories with mode `0700` and files with mode
+`0600`.
+
+### Conversation and lookup deduplication
+
+A conversation owns exactly one trace file. Within that file, a distinct lookup
+is identified by `lookup_id`, a SHA-256 fingerprint of canonical JSON containing
+the conversation session ID, query, ordered executed command arguments,
+selected base names, selected hierarchy paths, and source scopes. Exclude
+timestamps, durations, routing scores, outcomes, and explanatory prose from the
+fingerprint.
+
+Append a new JSON Lines record only when its `lookup_id` is absent. When the same
+lookup occurs again, update its existing record, increment `occurrence_count`,
+append a complete timing snapshot to `attempts`, refresh `finished_at` and the
+latest observable outcome, and accumulate `duration_ms`. Preserve distinct
+queries, commands, targets, hierarchy paths, and source scopes as distinct
+records. Serialize same-conversation updates and replace the file atomically so
+concurrent searches cannot create duplicate files, duplicate records, partial
+lines, or lost attempts.
+
+### JSON Lines record
+
+Each nonempty line is one independent UTF-8 JSON object:
+
+```json
+{
+  "version": 1,
+  "started_at": "2026-08-06T09:02:00.000-07:00",
+  "finished_at": "2026-08-06T09:02:00.087-07:00",
+  "duration_ms": 87,
+  "session_id": "019fa5de-c89c-7402-ad74-2978a02a04ad",
+  "lookup_id": "sha256:5bc3d31d3d6e5c2df4c7fd4cc882443d8f89aa6bc6004e15a5f80f0beef7cfc1",
+  "occurrence_count": 1,
+  "query": "gateway authentication",
+  "commands": [
+    {"argv": ["python3", "./scripts/mem.py", "context", "lookup", "--query", "gateway authentication", "--target", "claw"],
+     "command": "python3 ./scripts/mem.py context lookup --query 'gateway authentication' --target claw",
+     "started_at": "2026-08-06T09:02:00.000-07:00", "finished_at": "2026-08-06T09:02:00.087-07:00", "duration_ms": 87}
+  ],
+  "operations": [
+    {"name": "load_config", "started_at": "2026-08-06T09:02:00.002-07:00", "finished_at": "2026-08-06T09:02:00.008-07:00", "duration_ms": 6},
+    {"name": "route", "started_at": "2026-08-06T09:02:00.009-07:00", "finished_at": "2026-08-06T09:02:00.012-07:00", "duration_ms": 3},
+    {"name": "resolve_schemas", "started_at": "2026-08-06T09:02:00.013-07:00", "finished_at": "2026-08-06T09:02:00.021-07:00", "duration_ms": 8},
+    {"name": "search_managed", "started_at": "2026-08-06T09:02:00.022-07:00", "finished_at": "2026-08-06T09:02:00.082-07:00", "duration_ms": 60}
+  ],
+  "attempts": [
+    {"started_at": "2026-08-06T09:02:00.000-07:00", "finished_at": "2026-08-06T09:02:00.087-07:00", "duration_ms": 87,
+     "command_timings": [{"command_index": 0, "started_at": "2026-08-06T09:02:00.000-07:00", "finished_at": "2026-08-06T09:02:00.087-07:00", "duration_ms": 87}],
+     "operation_timings": [
+       {"name": "load_config", "started_at": "2026-08-06T09:02:00.002-07:00", "finished_at": "2026-08-06T09:02:00.008-07:00", "duration_ms": 6},
+       {"name": "route", "started_at": "2026-08-06T09:02:00.009-07:00", "finished_at": "2026-08-06T09:02:00.012-07:00", "duration_ms": 3},
+       {"name": "resolve_schemas", "started_at": "2026-08-06T09:02:00.013-07:00", "finished_at": "2026-08-06T09:02:00.021-07:00", "duration_ms": 8},
+       {"name": "search_managed", "started_at": "2026-08-06T09:02:00.022-07:00", "finished_at": "2026-08-06T09:02:00.082-07:00", "duration_ms": 60}
+     ],
+     "status": "matched"}
+  ],
+  "selection": {"tier": "explicit", "bases": ["claw"], "reasons": ["explicit base name"]},
+  "hierarchy": [
+    {"path": "/Users/kevinlin/code/openclaw/.mem/main/pkg/clawgateway", "schema": "pkg", "decision": "searched",
+     "reason": "The gateway query matches the package knowledge hierarchy."}
+  ],
+  "fallback": {"used": false, "paths": [], "reason": "Managed knowledge already contained a matching document."},
+  "status": "matched",
+  "matched_paths": ["/Users/kevinlin/code/openclaw/.mem/main/pkg/clawgateway/ref/authentication.md"]
+}
+```
+
+`started_at`, `finished_at`, `duration_ms`, `lookup_id`, `occurrence_count`,
+`query`, `commands`, `operations`, `attempts`, and `hierarchy` are required.
+Every lookup, executed command, and operation has timezone-aware ISO 8601
+start/end timestamps with millisecond precision plus a nonnegative elapsed
+`duration_ms` measured from a monotonic clock. Top-level `started_at` is the
+first attempt, `finished_at` is the latest attempt, `duration_ms` is the sum of
+attempt durations, and `operations` reflects the latest attempt. `attempts`
+retains every attempt's command timing, per-stage timing, and terminal status.
+`operations` is ordered and records actual stages such as `load_config`,
+`route`, `resolve_schemas`, `search_managed`, and `search_source` when fallback
+occurs. Do not create operation entries for stages that did not run.
+
+`commands[].argv` preserves the exact executed argument tokens;
+`commands[].command` is their safely quoted, replayable shell representation.
+Record only commands that actually executed; internal function calls are not
+fabricated as CLI invocations.
+
+Each `hierarchy` entry explains an observed path decision with `path`, `schema`,
+`decision`, and a concise evidence-backed `reason`. Record actual selected bases,
+schema descriptions or nodes, searched managed paths, and source-fallback paths;
+do not invent model reasoning or claim deterministic node inference that did not
+occur. `selection`, `fallback`, `status`, and `matched_paths` connect those
+decisions to the observable outcome. Failed or ambiguous audited lookups are
+recorded with their real status and empty fields where no selection occurred.
+
+Tracing may write only inside the configured trace root; managed knowledge and
+source scopes remain unmodified. Do not capture environment variables, file
+bodies, credentials, or unrelated shell commands. If the session ID is missing
+or unsafe, or the trace destination cannot be created or updated, stop the
+audit-enabled lookup with an explicit audit error instead of silently running an
+unlogged search. Audit-disabled lookups create no trace directories or files.
+
+## Implementation
+
+1. Extend `scripts/load_config.py` to validate, merge, normalize, and expose the
+   optional audit settings without changing existing base behavior.
+2. Add a focused trace writer that resolves the current conversation ID, reuses
+   its first-date trace path, fingerprints lookups, enforces permissions, and
+   merges duplicate records under a conversation-scoped lock.
+3. Instrument `scripts/context.py` and the unified CLI boundary to capture the
+   real query, executed argv, routing reasons, hierarchy decisions, source
+   fallback, terminal status, and monotonic timings for commands and stages.
+4. Document configuration and trace fields in the public `mem` `README.md` and
+   `CLI.md`; keep the runtime skill mirror generated from the canonical source.
+
+## Verification
+
+- Disabled or absent audit settings preserve existing output and create no trace.
+- Enabled audit writes to the default or configured root under `YYYY/MM/DD` with
+  the validated conversation session ID as the `.jsonl` filename.
+- A conversation creates exactly one trace file; lookups after midnight reuse
+  the folder chosen by the conversation's first audited lookup.
+- Repeating the same lookup updates one record, increments `occurrence_count`,
+  and retains each attempt's command and operation timings; distinct lookups
+  produce separate, independently parseable JSON Lines records.
+- Concurrent lookups from the same conversation cannot create duplicate files,
+  duplicate fingerprints, partial records, or lost timing history.
+- Every record preserves the actual query, exact argv and replayable command,
+  selected hierarchy paths with grounded reasons, routing outcome, and fallback.
+- Every lookup, executed command, and actual operation records valid start/end
+  timestamps and a nonnegative monotonic duration; fallback timing appears only
+  when source fallback actually runs.
+- Ambiguous, unmatched, and invalid lookups record their actual terminal status.
+- Invalid config, missing session IDs, unsafe paths, permission failures, and
+  update failures stop audit-enabled searches without touching knowledge files.
+- Trace directories and files have modes `0700` and `0600`; environment values,
+  file contents, secrets, and fabricated commands never appear in records.
+
+## Manual Notes
+
+[keep this for the user to add notes. do not change between edits]
+
+## Changelog
+- 2026-08-06 09:15: Moved the skill-owned feature specification into the canonical public skills repository (019fd474-e957-75e3-8610-647bebd4a0bb - aca5b49)
+- 2026-08-06 09:07: Defined one-file-per-conversation deduplication and fingerprinted lookup records with retained timing history (019fa5de-c89c-7402-ad74-2978a02a04ad - 568f4ac4ba173)
+- 2026-08-06 09:03: Added lookup, command, and per-operation timestamps with monotonic elapsed durations (019fa5de-c89c-7402-ad74-2978a02a04ad - 568f4ac4ba173)
+- 2026-08-06 09:02: Created the audit configuration and conversation-scoped JSON Lines trace format specification (019fa5de-c89c-7402-ad74-2978a02a04ad - 568f4ac4ba173)


### PR DESCRIPTION
## Summary
- add opt-in audit configuration with nearest-config precedence and normalized trace roots
- add conversation-scoped, atomic JSONL lookup traces with stable fingerprints and deduplicated attempt history
- add audited context lookup instrumentation, documentation, and comprehensive concurrency/security coverage

## Testing
- `python3 -m unittest discover -s active/mem/scripts/tests -p "test_*.py"` (76 passed)
- `python3 active/sc/scripts/quick_validate.py active/mem`
- packaged skill archive integrity check
- canonical and runtime mem skill trees match byte-for-byte

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only context lookup with managed routing, schema resolution, source fallback, and formatted results.
  * Added optional secure audit tracing with timing, lookup details, deduplication, and conversation-scoped records.
  * Added audit configuration with defaults, environment variables, path resolution, and inheritance.
  * Added support for matching multiple source scopes during routing.

* **Documentation**
  * Added comprehensive CLI, configuration, lookup, audit, security, and schema documentation.

* **Tests**
  * Added extensive coverage for lookup, configuration, audit traces, concurrency, validation, privacy, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->